### PR TITLE
DOCSINFRA-141 Add alignment properties to the tables

### DIFF
--- a/src/css/adoc/table.css
+++ b/src/css/adoc/table.css
@@ -43,3 +43,21 @@ table.tableblock {
     }
   }
 }
+td.tableblock.valign-top {
+  vertical-align: top;
+}
+td.tableblock.valign-middle {
+  vertical-align: middle;
+}
+td.tableblock.valign-bottom {
+  vertical-align: bottom;
+}
+td.tableblock.halign-center {
+  text-align: center;
+}
+td.tableblock.halign-left {
+  text-align: left;
+}
+td.tableblock.halign-right {
+  text-align: right;
+}


### PR DESCRIPTION
Added css properties to our table's style so that we can use the asciidoc table alignment properties in our content.

@mojavelinux I would think these style declarations can be made simpler? Or do I need to specifically declare each alignment as I did here? 

I tested against a local UI bundle and the results are the expected ones:

<.< aligns to left and top
<.^ aligns to left and center
<.> aligns to left and bottom

^.< aligns to middle and top
^.^ aligns to middle and center
^.> aligns to middle and bottom

\>.< aligns to right and top
\>.^ aligns to right and center
\>.> aligns to right and bottom

This change also makes our default alignment to be **<.< (aligns to left and top)**