### PR TITLE
Remove unnecesay GDPR banner

### DIFF
--- a/src/partials/footer.hbs
+++ b/src/partials/footer.hbs
@@ -1,10 +1,3 @@
 {{> footer-content}}
-<div class="modal-backdrop"></div>
-<div class="gdpr js-gdpr">
-  <div class="gdpr-container">
-    <p class="gdpr-text">We use cookies to make interactions with our websites and services easy and meaningful, to better understand how they are used and to tailor advertising. You can read more and make your cookie choices <a class="link" href="//mulesoft.com/privacy-policy">here</a>. By continuing to use this site you are giving us your consent to do this.</p>
-    <button class="gdpr-close js-gdpr-close">+</button>
-  </div>
-</div>
 
 {{> footer-scripts}}


### PR DESCRIPTION
After the updates made in the header and footer, this PR removes the unnecessary GDPR banner from the docs site.