### PR TITLE
Tweak the connectors helper to allow partial builds

### DIFF
--- a/src/helpers/connectors.js
+++ b/src/helpers/connectors.js
@@ -5,5 +5,7 @@ module.exports = function ({
     root: { site },
   },
 }) {
-  return Object.values(site.components).filter(({ asciidoc }) => asciidoc.attributes['page-connector-type'])
+  return Object.values(site.components).filter(
+    ({ asciidoc = { attributes: {} } }) => asciidoc.attributes['page-connector-type']
+  )
 }


### PR DESCRIPTION
Partial builds that include connectors fail with the error:

Cannot read property 'attributes' of undefined in UI template partials/connectors-table.hbs

The issue is that when the components are imported from the primary site, those components do not include the asciidoc property from the component descriptor. The template was assuming this property is always set.  This introduces a fallback.  