### PR TITLE
var fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!/bin/env groovy
 
 def gitBranch = 'master'
-def githubApiCredentialsId = 'GH_TOKEN'
+def githubCredentialsId = 'GH_TOKEN'
 
 pipeline {
   agent any


### PR DESCRIPTION
### Bugfix

Line 39 references a credentials variable `githubCredentialsId` which does not match the variable named `githubApiCredentialsId`. Running a Jenkins build will fail as a result since `githubCredentialsId` does not exist. I rename the variable name to githubCredentialsId. 