### PR TITLE
add survey toc to connectors

### DIFF
--- a/src/partials/connectors/connectors-sidebar.hbs
+++ b/src/partials/connectors/connectors-sidebar.hbs
@@ -35,3 +35,4 @@
     {{/if}}
   </section>
 </div>
+{{> survey-toc}}


### PR DESCRIPTION
missing the TOC survey from the connectors page. I am adding it back