### PR TITLE
W-10736467 Fix survey position for Connectors pages

### DIFF
--- a/src/layouts/default.hbs
+++ b/src/layouts/default.hbs
@@ -30,6 +30,7 @@
       <div class="js-toc">
         <nav class="toc-menu"></nav>
       </div>
+{{> survey-toc}}
     </aside>
   </div>
   {{else}}

--- a/src/partials/connectors/connectors-sidebar.hbs
+++ b/src/partials/connectors/connectors-sidebar.hbs
@@ -35,4 +35,3 @@
     {{/if}}
   </section>
 </div>
-{{> survey-toc}}


### PR DESCRIPTION
Fixed survey position for Connectors pages

Currently live incorrect position:
![Screen Shot 2022-03-11 at 11 45 13 AM](https://user-images.githubusercontent.com/47541849/157890044-9975a044-4ed7-4f70-8788-093ca463c30b.png)

New fixed position:
![Screen Shot 2022-03-11 at 11 45 32 AM](https://user-images.githubusercontent.com/47541849/157890096-b7c2af4e-737a-406d-a742-9e19b88bb0ee.png)

Could you double check this on your end to make sure it looks good? The localhost preview shows only Salesforce Connector and http://localhost:5252/salesforce-connector-authentication.html page was the only page that has an available TOC on the right to test the correct position.
Can this be tested with a different connector page? How is that done?

