### PR TITLE
[W-10592784] add link to connector support level

### DIFF
--- a/src/partials/connectors/connectors-sidebar.hbs
+++ b/src/partials/connectors/connectors-sidebar.hbs
@@ -15,7 +15,9 @@
     <div class="col">Level</div>
     <div class="col">
       <div class="flex align-center">
-        {{{page.attributes.connector-level}}}
+        <a target="_blank" rel="noopener noreferrer" href="https://www.mulesoft.com/legal/versioning-back-support-policy#anypoint-connectors">
+          {{{page.attributes.connector-level}}}
+        </a>
         <div class="flex align-center justify-center level-help js-connector-level-trigger" data-level="{{{page.attributes.connector-level}}}">
           <svg class="icon icon-help"><use xlink:href="#icon-help"/></svg>
         </div>


### PR DESCRIPTION
ref: [W-10592784](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000laYdNYAU/view)

In the sidebar of connector pages (e.g. https://docs.mulesoft.com/amazon-kinesis-connector/1.0/), add a link to the level value. It's the same link for all support levels (select or premium).

To test, run `gulp preview` in this branch, then navigate to http://localhost:5252/connector.html and click "Select" in the sidebar. Doing so will open the [support policy page|https://www.mulesoft.com/legal/versioning-back-support-policy#anypoint-connectors] *in a new tab*.