### PR TITLE
[W-10592990] unhide breadcrumbs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@mulesoft/docsinfra

--- a/src/css/specific/toolbar.css
+++ b/src/css/specific/toolbar.css
@@ -11,10 +11,6 @@
     padding-right: var(--xl);
   }
 
-  @media (--md) {
-    display: none;
-  }
-
   @supports (backdrop-filter: blur(10px)) {
     backdrop-filter: blur(10px);
     background: rgba(255,255,255,.7);


### PR DESCRIPTION
ref: W-10592990

- unhide breadcrumbs from bigger screens. Previously there were only visible in small screens.
- add docsinfra as codeowners

![Screen Shot 2022-04-12 at 1 46 12 PM](https://user-images.githubusercontent.com/10934908/163050908-a7e3df1f-ba8f-4173-ae14-8b604e37cf17.png)