### PR TITLE
[W-11071630] adjust survey TOC CSS for Safari

### DIFF
--- a/src/css/components/survey.css
+++ b/src/css/components/survey.css
@@ -23,7 +23,7 @@ div.survey-icon {
 }
 
 div.survey-title {
-  display: block;
+  display: inline-block;
   font-family: var(--sans-serif);
   font-size: 20px;
   font-style: normal;
@@ -37,17 +37,17 @@ div.survey-title {
 
 div.survey-text {
   align-items: center;
-  display: block;
+  display: inline-block;
   font-family: var(--sans-serif);
   font-size: 15px;
   font-style: normal;
   font-weight: normal;
   line-height: 20px;
-  margin: auto;
+  margin: auto 10%;
   position: inherit;
   text-align: center;
   top: 6%;
-  width: 80%;
+  width: auto;
 }
 
 a.survey-button {

--- a/src/partials/survey-toc.hbs
+++ b/src/partials/survey-toc.hbs
@@ -25,8 +25,7 @@
   </div>
   <div class="survey-title">Submit your <br> feedback!</div>
   <div class="survey-text"><p>Share your thoughts to help us build the best documentation experience for you!</p></div>
-  <a class="survey-button" type="button" href="https://s2.userzoom.com/m/MSBDNTQxOFMxMzI4" target="_blank">Take our latest
+  <a class="survey-button" href="https://s2.userzoom.com/m/MSBDNTQxOFMxMzI4" target="_blank">Take our latest
   survey!</a>
-
 </section>
 {{/unless}}


### PR DESCRIPTION
ref: [W-11071630](https://gus.my.salesforce.com/a07EE00000vxGusYAE)

## Bug Fix

- remove `type="button"` from survey TOC element. It was breaking the element appearance in Safari

## Enhancement

- slight adjustments on the survey element CSS so it looks better on Safari

## Validations

These screenshots are taken from Safari. The layouts are not perfect but we can fix them later.

![Screen Shot 2022-04-29 at 2 15 54 PM](https://user-images.githubusercontent.com/10934908/166070209-6882209a-bd0d-4adb-9d40-c7ba8b725e11.png)

![Screen Shot 2022-04-29 at 2 16 00 PM](https://user-images.githubusercontent.com/10934908/166070220-30738393-554d-4537-b4c0-cf430d08a9ad.png)

