### PR TITLE
[W-10592497] add button to close modal

### DIFF
--- a/src/css/vendor/coveo.css
+++ b/src/css/vendor/coveo.css
@@ -18,6 +18,8 @@
 
   /* close button */
   & .coveo-close {
+    background-color: var(--aluminum-1);
+    border: none;
     cursor: pointer;
     fill: var(--aluminum-4);
     height: var(--lg);

--- a/src/partials/search.hbs
+++ b/src/partials/search.hbs
@@ -4,7 +4,11 @@
   <div class="modal">
     <header class="flex align-center coveo-searchbox-wrapper">
       <div class="CoveoSearchbox" data-placeholder="Search docs" data-enable-search-as-you-type="true" data-search-as-you-type-delay="2000"></div>
-      <svg class="flex shrink coveo-close js-search-close" width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M19.9174 1.40828C19.5074 0.935478 19.0645 0.492569 18.5917 0.0825958L10 8.67432L1.40828 0.0825958C0.935478 0.492569 0.492569 0.935478 0.0825958 1.40828L8.67432 10L0.0825964 18.5917C0.49257 19.0645 0.935479 19.5074 1.40828 19.9174L10 11.3257L18.5917 19.9174C19.0645 19.5074 19.5074 19.0645 19.9174 18.5917L11.3257 10L19.9174 1.40828Z"/></svg>
+      <button aria-label="Close modal" class="flex shrink coveo-close js-search-close" title="Close" data-close="" type="button">
+        <svg class="flex shrink" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+          <path d="M19.9174 1.40828C19.5074 0.935478 19.0645 0.492569 18.5917 0.0825958L10 8.67432L1.40828 0.0825958C0.935478 0.492569 0.492569 0.935478 0.0825958 1.40828L8.67432 10L0.0825964 18.5917C0.49257 19.0645 0.935479 19.5074 1.40828 19.9174L10 11.3257L18.5917 19.9174C19.0645 19.5074 19.5074 19.0645 19.9174 18.5917L11.3257 10L19.9174 1.40828Z"/>
+        </svg>
+      </button>
     </header>
     <div class="coveo-main-section">
       <section class="coveo-facet-column">


### PR DESCRIPTION
ref: [W-10592497](https://gus.lightning.force.com/a07EE00000laXUbYAM)

## Enhancements

The search modal's close "button" used to have only a svg tag. I have wrapped it within a proper button tag so that it is an actual button. The button is borderless and has a very light gray background color that is visible in all major browsers (Chrome, Safari, Firefox) to make it look like a real button, but not dark enough to hide the X icon. Moreover, hovering on the button will show the tooltip text "Close", further clarifying what the button does (but this can be reworded as "Close search", "Close window" and others). 

When not hovered
![Screen Shot 2022-05-09 at 2 50 15 PM](https://user-images.githubusercontent.com/10934908/167504851-a759fe4a-2848-4c09-bf25-2025bddca3b7.png)

When hovered
![Screen Shot 2022-05-09 at 2 45 46 PM](https://user-images.githubusercontent.com/10934908/167504117-ebd9dc29-57df-40b1-9a0d-b42771098e41.png)