### PR TITLE
[W-11173514] adding noindex meta tag

### DIFF
--- a/src/layouts/404.hbs
+++ b/src/layouts/404.hbs
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    {{#if (ne (site-profile) 'prod')}}
+    {{#if (and (ne (site-profile) 'jp') (ne (site-profile) 'prod'))}}
     <meta name="robots" content="noindex">
     {{/if}}
     <title>{{{detag (or page.title 'Page Not Found')}}}{{#if site.title}} | {{{site.title}}}{{/if}}</title>

--- a/src/layouts/404.hbs
+++ b/src/layouts/404.hbs
@@ -4,6 +4,9 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    {{#if (ne (site-profile) 'prod')}}
+    <meta name="robots" content="noindex">
+    {{/if}}
     <title>{{{detag (or page.title 'Page Not Found')}}}{{#if site.title}} | {{{site.title}}}{{/if}}</title>
     {{> head}}
 </head>

--- a/src/layouts/connectors-home.hbs
+++ b/src/layouts/connectors-home.hbs
@@ -13,7 +13,7 @@
 {{#if page.keywords}}
 <meta name="keywords" content="{{page.keywords}}">
 {{/if}}
-{{#if (ne (site-profile) 'prod')}}
+{{#if (and (ne (site-profile) 'jp') (ne (site-profile) 'prod'))}}
 <meta name="robots" content="noindex">
 {{/if}}
 {{> head}}

--- a/src/layouts/connectors-home.hbs
+++ b/src/layouts/connectors-home.hbs
@@ -13,6 +13,9 @@
 {{#if page.keywords}}
 <meta name="keywords" content="{{page.keywords}}">
 {{/if}}
+{{#if (ne (site-profile) 'prod')}}
+<meta name="robots" content="noindex">
+{{/if}}
 {{> head}}
 </head>
 <body class="flex col">

--- a/src/layouts/default.hbs
+++ b/src/layouts/default.hbs
@@ -13,7 +13,7 @@
 {{#if page.keywords}}
 <meta name="keywords" content="{{page.keywords}}">
 {{/if}}
-{{#if (ne (site-profile) 'prod')}}
+{{#if (and (ne (site-profile) 'jp') (ne (site-profile) 'prod'))}}
 <meta name="robots" content="noindex">
 {{/if}}
 {{> head}}

--- a/src/layouts/default.hbs
+++ b/src/layouts/default.hbs
@@ -13,6 +13,9 @@
 {{#if page.keywords}}
 <meta name="keywords" content="{{page.keywords}}">
 {{/if}}
+{{#if (ne (site-profile) 'prod')}}
+<meta name="robots" content="noindex">
+{{/if}}
 {{> head}}
 </head>
 <body class="flex col">

--- a/src/layouts/rtfcloud-home.hbs
+++ b/src/layouts/rtfcloud-home.hbs
@@ -13,7 +13,7 @@
 {{#if page.keywords}}
 <meta name="keywords" content="{{page.keywords}}">
 {{/if}}
-{{#if (ne (site-profile) 'prod')}}
+{{#if (and (ne (site-profile) 'jp') (ne (site-profile) 'prod'))}}
 <meta name="robots" content="noindex">
 {{/if}}
 {{> head}}

--- a/src/layouts/rtfcloud-home.hbs
+++ b/src/layouts/rtfcloud-home.hbs
@@ -13,6 +13,9 @@
 {{#if page.keywords}}
 <meta name="keywords" content="{{page.keywords}}">
 {{/if}}
+{{#if (ne (site-profile) 'prod')}}
+<meta name="robots" content="noindex">
+{{/if}}
 {{> head}}
 </head>
 <body class="flex col">


### PR DESCRIPTION
ref: W-11173514

note: to use this UI bundle, you will have to add this to the antora playbook:

```yaml
site:
# ...
  keys:
    site_profile: prod
```

## Bug Fixes

add a `noindex` meta tag to all pages that are not prod or jp, based on https://developers.google.com/search/docs/advanced/crawling/block-indexing which is the recommended way to tell web crawlers to not index pages. Traditionally, robots.txt was used to block crawlers from the beta pages, but according to [Google](https://developers.google.com/search/docs/advanced/robots/intro#understand-the-limitations-of-a-robots.txt-file):

> **A page that's disallowed in robots.txt can still be indexed if linked to from other sites.**
While Google won't crawl or index the content blocked by a robots.txt file, we might still find and index a disallowed URL if it is linked from other places on the web. As a result, the URL address and, potentially, other publicly available information such as anchor text in links to the page can still appear in Google search results. To properly prevent your URL from appearing in Google search results, [password-protect the files on your server](https://developers.google.com/search/docs/advanced/crawling/control-what-you-share), [use the noindex meta tag or response header](https://developers.google.com/search/docs/advanced/crawling/block-indexing), or remove the page entirely.

A caveat is that:

> Important: For the noindex directive to be effective, the page or resource must not be blocked by a robots.txt file, and it has to be otherwise accessible to the crawler. If the page is blocked by a robots.txt file or the crawler can't access the page, the crawler will never see the noindex directive, and the page can still appear in search results, for example if other pages link to it.

I think we can try this out without removing robots.txt. If the beta pages are still showing on the Google search results, then we can remove robots.txt from the playbooks.

## How to validate

1. Open this repo and switch to the **W-11173514-noindex** branch
2. Run `gulp bundle` to create a local ui-bundle zip file
3. Open antora-playbook, switch to the **beta** branch
4. Open beta-flex-gateway.yml, note that site.keys.site_profile value is **beta**. Update ui.bundle.url value to <path>/docs-site-ui/build/ui-bundle.zip. Leave the file open.
5. Run `make gen-site playbook=beta-flex-gateway.yml` to build a local beta site and open it. Look at the source and validate that `<meta name="robots" content="noindex">` is present in <head>
6. Return to beta-flex-gateway.yml and update site.keys.site_profile to **prod**, save the file (but don't commit. It's just for testing)
7. Run `make gen-site playbook=beta-flex-gateway.yml` to build a local beta site and open it. Look at the source and validate that `<meta name="robots" content="noindex">` is NOT present in <head>
8. Return to beta-flex-gateway.yml and update site.keys.site_profile to **jp**, save the file (but don't commit. It's just for testing)
9. Run `make gen-site playbook=beta-flex-gateway.yml` to build a local beta site and open it. Look at the source and validate that `<meta name="robots" content="noindex">` is NOT present in <head>