### PR TITLE
[W-10592545] alt text for external links

### DIFF
--- a/preview-site-src/element-examples.adoc
+++ b/preview-site-src/element-examples.adoc
@@ -214,6 +214,8 @@ https://docs.antora.org/antora/latest/asciidoc/external-urls/[ref]
 Looking for help?
 Visit the https://antora.zulipchat.com[Antora chat room].
 
+This is the https://antora.zulipchat.com[external link^] for the same URL.
+
 == Xref
 
 https://docs.antora.org/antora/latest/asciidoc/in-page-xref/[ref]

--- a/src/js/09-external-links.js
+++ b/src/js/09-external-links.js
@@ -1,0 +1,12 @@
+;(function () {
+  'use strict'
+
+  // Add alt text/title to external links.
+  // See https://stackoverflow.com/questions/4216035/css-background-image-alt-attribute
+  // on why this is done using JS instead of CSS.
+  var externalLinks = document.querySelectorAll('[target="_blank"]')
+
+  externalLinks.forEach(function (link) {
+    link.title = 'leaving the site'
+  })
+})()


### PR DESCRIPTION
ref: [W-10592545](https://gus.lightning.force.com/a07EE00000laXVNYA2)

## enhancements

add "alt text" to the external link icon. See https://stackoverflow.com/questions/4216035/css-background-image-alt-attribute why it is done in JS instead of CSS. _tl;dr you can't add the alt attribute in CSS, and alt doesn't apply to <a> elements, but title does the same thing._

### how to test

use `gulp preview` and go to http://localhost:5252/element-examples.html#_url. There is an external link there, hover on it and it should display "leaving the site". You can do the same for the salesforce icon at the top.