### PR TITLE
[W-10592499] make toc tab outline show in Chrome

### DIFF
--- a/src/css/globals/typography.css
+++ b/src/css/globals/typography.css
@@ -88,7 +88,6 @@ h6 {
     color: var(--steel-4);
   }
 
-
   &:focus,
   &:active {
     color: var(--core-blue-3);

--- a/src/css/globals/typography.css
+++ b/src/css/globals/typography.css
@@ -88,9 +88,6 @@ h6 {
     color: var(--steel-4);
   }
 
-  &:focus {
-    outline: 0;
-  }
 
   &:focus,
   &:active {

--- a/src/css/specific/navigation.css
+++ b/src/css/specific/navigation.css
@@ -184,7 +184,6 @@ button.subnav-toggle {
   z-index: 1;
   &:focus {
     box-shadow: none;
-    outline: 0;
   }
   &::before {
     content: "+";
@@ -192,6 +191,10 @@ button.subnav-toggle {
     text-align: center;
     width: 1.5em;
   }
+}
+
+.nav-li {
+  margin: 1px;
 }
 
 .nav-li.active > button.subnav-toggle::before {

--- a/src/css/specific/toc.css
+++ b/src/css/specific/toc.css
@@ -28,9 +28,6 @@
   padding: var(--xs) var(--sm);
   text-decoration: none;
 
-  &:focus {
-    outline: 0;
-  }
 
   &:hover,
   &:focus,

--- a/src/css/specific/toc.css
+++ b/src/css/specific/toc.css
@@ -28,7 +28,6 @@
   padding: var(--xs) var(--sm);
   text-decoration: none;
 
-
   &:hover,
   &:focus,
   &:active {


### PR DESCRIPTION
ref: W-10592499

**Note that this does not solve the main issue in the GUS ticket, but it's a good place to start. Only test this in Google Chrome as it is not yet compatible with Safari and Firefox.**

Currently in Chrome, the left TOC menu items are tab-able, but they do not have an outline so from an accessibility's perspective, it's hard to see which tab is the current focus. For example, if you go to https://docs.mulesoft.com/ right now and keep pressing the tab key to reach the TOC menu, you will see on the lower left corner that the browser is focusing on the menu items with different URLs, but there's nothing in the UI showing the focus.

This PR removes the `outline: 0` attributes from CSS to make the outlines show again:
![Screen Shot 2022-05-20 at 2 44 21 PM](https://user-images.githubusercontent.com/10934908/169617149-37642a69-f629-45f4-8786-6e0ab44edb38.png)

To test, please run `gulp preview`, open http://localhost:5252/ in Google Chrome, and keep pressing the tab key. You will see the outlines!

Lastly, I added a slim margin around each menu items, otherwise the outline would not appear correctly (some borders are too high or too low and blocked by other elements). In the following screenshot, the left is the current look and the right is after adding the margin, and you can see that there is a little extra space between these items which slightly increases the height, but the difference is minimal.

![Screen Shot 2022-05-20 at 2 53 18 PM](https://user-images.githubusercontent.com/10934908/169617527-f97a4c38-76c9-4ff2-aa71-cc613f4b1b6b.png)

