### PR TITLE
[W-10592950] fix ol styles

### DIFF
--- a/src/css/adoc/doc.css
+++ b/src/css/adoc/doc.css
@@ -249,8 +249,32 @@
     }
   }
 
-  & ol {
+  & ol.arabic {
     list-style-type: decimal;
+  }
+
+  & ol.decimal {
+    list-style-type: decimal-leading-zero;
+  }
+
+  & ol.loweralpha {
+    list-style-type: lower-alpha;
+  }
+
+  & ol.upperalpha {
+    list-style-type: upper-alpha;
+  }
+
+  & ol.lowerroman {
+    list-style-type: lower-roman;
+  }
+
+  & ol.upperroman {
+    list-style-type: upper-roman;
+  }
+
+  & ol.lowergreek {
+    list-style-type: lower-greek;
   }
 
   & ul {


### PR DESCRIPTION
ref: [W-10592950](https://gus.lightning.force.com/a07EE00000laaDDYAY)

allow ordered lists to use a different numbering or lettering scheme (e.g., arabic, alpha, roman, etc) instead of only numbers.

![Screen Shot 2022-05-23 at 4 17 35 PM](https://user-images.githubusercontent.com/10934908/169919575-faf8fdb7-0953-4cbd-9500-c2e6997a8095.png)

## How to test

run `gulp preview` and open http://localhost:5252/element-examples.html#_list to validate that the numbers are displayed in different format based on the heading (roman, arabic, greek), instead of all arabic numbers.