### PR TITLE
[W-11256404] parameterize connector icon extension

### DIFF
--- a/preview-site-src/ui-model.yml
+++ b/preview-site-src/ui-model.yml
@@ -215,6 +215,30 @@ site:
             url: /salesforce-connector/salesforce-connector.html
           - content: Salesforce Connector Authentication
             url: /salesforce-connector/salesforce-connector-authentication.html
+    amazon-sns-connector:
+      latest: &s3_connector_latest
+        version: '4.7'
+        display_version: 4.7 (Mule 4)
+        title: Amazon SNS Connector
+        url: /placeholder.html
+        asciidoc:
+          attributes:
+            page-component-desc: Provides connectivity to the Amazon Simple Notification Service (Amazon SNS) API, enabling you to build distributed web-enabled applications.
+            page-connector-type: Connector
+            page-connector-level: Select
+            page-exchange-group-id: com.mulesoft.connectors
+            page-exchange-asset-id: mule-amazon-sns-connector
+            page-icon-extension: png
+            page-runtime-version: 4.1.1
+            page-release-notes-page: release-notes::connector/amazon-sns-connector-release-notes-mule-4.adoc
+            page-vendor-name: amazon
+            page-vendor-title: Amazon
+        navigation:
+        - items:
+          - content: Dead page (do not click)
+            url: '#'
+      versions:
+      - *s3_connector_latest
 page:
   src:
     component: general

--- a/src/css/specific/header.css
+++ b/src/css/specific/header.css
@@ -10,7 +10,7 @@
   z-index: var(--z-header);
 
   @media (min-width: 991px) {
-      height: 93px;
+    height: 93px;
   }
 }
 

--- a/src/css/specific/header.css
+++ b/src/css/specific/header.css
@@ -5,7 +5,7 @@
 
 /* specificity to override position */
 .ms-com-content.ms-com-content.ms-com-content-header:not(.ms-com-content-header-with-banner) {
-  height: 100px;  
+  height: 100px;
   position: relative;
   z-index: var(--z-header);
 

--- a/src/helpers/isNull.js
+++ b/src/helpers/isNull.js
@@ -1,0 +1,3 @@
+'use strict'
+
+module.exports = (val) => val == null

--- a/src/partials/connectors/connectors-table.hbs
+++ b/src/partials/connectors/connectors-table.hbs
@@ -57,7 +57,7 @@
   {
     "title": "{{connector.title}}",
     "type": "{{attributes.page-connector-type}}",
-    "iconURL": "https://anypoint.mulesoft.com/exchange/organizations/68ef9520-24e9-4cf2-b2f5-620025690913/assets/{{attributes.page-exchange-group-id}}/{{attributes.page-exchange-asset-id}}/icon/svg/",
+    "iconURL": "https://anypoint.mulesoft.com/exchange/organizations/68ef9520-24e9-4cf2-b2f5-620025690913/assets/{{attributes.page-exchange-group-id}}/{{attributes.page-exchange-asset-id}}/icon/{{#if (not (isNull attributes.page-icon-extension))}}{{attributes.page-icon-extension}}{{else}}svg{{/if}}/",
     {{#if attributes.page-exchange-asset-id}}
     "exchangeURL": "https://www.anypoint.mulesoft.com/exchange/{{attributes.page-exchange-group-id}}/{{attributes.page-exchange-asset-id}}/",
     {{/if}}


### PR DESCRIPTION
ref: [W-11256404](https://gus.lightning.force.com/a07EE00000yeGGmYAM)

make the connector icon extensions parameterized by a new page attribute named **page-icon-extension**. This allows each connector to specify in antora.yml what the extension is, for example png. If the attribute is omitted, the default extension is svg.

I added an amazon-sns-connector in the gulp preview site to demonstrate that it works. Its icon is in the png format, so on http://localhost:5252/connectors.html, all 4 icons (the other 3 are svg's) should display properly.

Also added a helper function, `isNull`, to help determine if an attribute is supplied or not.