### PR TITLE
[W-11404966] latex integration

### DIFF
--- a/preview-site-src/element-examples.adoc
+++ b/preview-site-src/element-examples.adoc
@@ -18,6 +18,17 @@ CAUTION: Don't stick forks in electric sockets.
 [#important]
 IMPORTANT: A monster lives in the basement.
 
+== MathJax
+
+Asciimath:
+asciimath:[`x/x={(1,if x!=0),(text{undefined},if x=0):}`]
+
+Latexmath:
+latexmath:[$C = \alpha + \beta Y^{\gamma} + \epsilon$]
+
+Stem:
+stem:[sqrt(4) = 2]
+
 == Code Blocks
 
 https://docs.antora.org/antora/latest/asciidoc/source/[ref]

--- a/src/partials/footer-scripts.hbs
+++ b/src/partials/footer-scripts.hbs
@@ -5,5 +5,14 @@
 {{#if (and page.component env.JIRA_COLLECTOR_ID)}}
 <script async src="{{uiRootPath}}/js/vendor/feedback.js" id="feedback-script" data-collector-id="{{env.JIRA_COLLECTOR_ID}}"></script>
 {{/if}}
+<script type="text/x-mathjax-config">
+MathJax.Hub.Config({
+  messageStyle: "none",
+  tex2jax: { inlineMath: [["\\(", "\\)"]], displayMath: [["\\[", "\\]"]], ignoreClass: "nostem|nolatexmath" },
+  asciimath2jax: { delimiters: [["\\$", "\\$"]], ignoreClass: "nostem|noasciimath" },
+  TeX: { equationNumbers: { autoNumber: "none" } }
+});
+</script>
+<script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_HTMLorMML"></script>
 {{> search}}
 {{> marketing-scripts}}


### PR DESCRIPTION
ref: W-11404966

- add mathjax support
- add examples for validation

How to validate:
1. Run `gulp preview`
2. Go to http://localhost:5252/element-examples.html#_mathjax and verify that all math formuli are displayed correctly