### PR TITLE
[W-11487023] add hideExistingVersions

### DIFF
--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -494,6 +494,7 @@
         instance.popper.classList.add('hide')
       },
       onShow: function (instance) {
+        hideExistingVersions()
         instance.popper.classList.remove('hide')
       },
       onShown: function (instance) {
@@ -551,6 +552,13 @@
 
   function cancelEvent (e) {
     e.stopPropagation()
+  }
+
+  function hideExistingVersions () {
+    var versions = document.querySelectorAll('.tippy-popper')
+    for (var i = 0, l = versions.length; i < l; i++) {
+      versions[i].classList.remove('shown')
+    }
   }
 
   function ignoreTouchScroll (e) {


### PR DESCRIPTION
ref: W-11487023

add a function to fix a bug where on mobile, after touching/tapping on 1 version and then another version, the dropdown menu for the first version is never hidden.

https://www.loom.com/share/8ee6bdaca6b9470190936192df97cd6c