### PR TITLE
[W-11541098] make search box stickier

### DIFF
--- a/src/css/specific/nav.css
+++ b/src/css/specific/nav.css
@@ -21,9 +21,12 @@
     -webkit-tap-highlight-color: transparent;
   }
   & .search {
+    background: white;
     box-shadow: 0 1px 0 var(--aluminum-3);
     display: flex;
     padding: var(--md);
+    position: sticky;
+    top: 0;
     z-index: inherit;
     & button {
       align-items: center;


### PR DESCRIPTION
ref: [W-11541098](https://gus.lightning.force.com/a07EE000013CbMeYAK)

fix a bug where search box does not stick at the bottom of the page.

before the fix (no search box at the top left corner of the page):
![Screen Shot 2022-08-04 at 12 27 14 PM](https://user-images.githubusercontent.com/10934908/182936512-91f0c67b-e8ea-4070-bd90-7c92668ebde6.png)

after the fix (search box is present!):
![Screen Shot 2022-08-04 at 12 27 22 PM](https://user-images.githubusercontent.com/10934908/182936533-008c2a46-9c01-4005-b683-bf8913a5994f.png)


https://www.loom.com/share/f6b21d067a0f48ee9ed3a8d6a3577506