### PR TITLE
[W-11558561] more flexible nav group organization

### DIFF
--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -107,7 +107,8 @@
       var groupComponents
       groupsAccum.push({
         iconId: groupIconId,
-        components: (groupComponents = Object.values(selectComponents(group.components, componentPool))),
+        components: (groupComponents = Object.values(
+          selectComponents(group.components, componentPool, group.exclude))),
         title: group.title,
         spreadSingleItem: group.spreadSingleItem,
       })
@@ -141,16 +142,18 @@
     })
   }
 
-  function selectComponents (patterns, pool) {
+  function selectComponents (patterns, pool, exclude) {
     return coerceToArray(patterns).reduce(function (accum, pattern) {
       if (~pattern.indexOf('*')) {
         var rx = new RegExp('^' + pattern.replace(/[*]/g, '.*?') + '$')
-        Object.keys(pool).forEach(function (candidate) {
-          if (rx.test(candidate)) {
-            accum[candidate] = pool[candidate]
-            delete pool[candidate]
-          }
-        })
+        Object.keys(pool)
+          .filter((x) => coerceToArray(exclude).indexOf(x) === -1)
+          .forEach(function (candidate) {
+            if (rx.test(candidate)) {
+              accum[candidate] = pool[candidate]
+              delete pool[candidate]
+            }
+          })
       } else if (pattern in pool) {
         accum[pattern] = pool[pattern]
         delete pool[pattern]

--- a/src/partials/banner.hbs
+++ b/src/partials/banner.hbs
@@ -7,7 +7,11 @@
         {{#if preview}}
         preview
         {{else}}
-        {{site-profile}}
+          {{#if (eq (site-profile) "archive")}}
+            archived
+          {{else}}
+            {{site-profile}}
+          {{/if}}
         {{/if}}
         MuleSoft Documentation.
         {{#if (eq (site-profile) "archive")}}


### PR DESCRIPTION
ref: [W-11558561](https://gus.lightning.force.com/a07EE000013OtsfYAC)

Add a new variable `exclude` for antora-navigator.yml, which can be used to exclude certain sections to be part of the nav group. This is most beneficial for the archive site at the moment, and possibly for production site in the future if we have multiple nav groups.

tl;dr (~7 minutes long) https://www.loom.com/share/446c56bddbbc4e18aa7e12aac6db13d1

As an example, let's say that in the archive site, here is my antora-navigator.yml:

```yml
groups:
- root: true
  components: home
- title: Docs by Product
  components: ['*', tcat-server]
output_file: site-navigation-data.js
```

and my playbook.yml branches:

```yml
content:
  sources:
  - url: https://github.com/mulesoft/docs-connector-devkit
    branches: v3(.){2..4}
  - url: https://github.com/mulesoft/docs-data-gateway
    branches: latest
  - url: https://github.com/mulesoft/docs-general
    branches: archive
  - url: https://github.com/mulesoft/docs-healthcare-toolkit
    branches: v3.1, v3.0, v2.0, v1.3
  - url: https://github.com/mulesoft/docs-munit
    branches: v1(.){0..2}
  - url: https://github.com/mulesoft/docs-tcat-server
    branches: v7.1
```

This will add a nav item named "general" in the **Docs by Product** nav group. The use of "*" as part of the components means that all docs sites *that are not already present in a previous nav group* are added to the nav group. In the case of the archive site, the "general" section is not pulled in a previous group and we still don't want "general" to be included in this group. Currently, the only way would be to not use "*" and instead, specify all the docs explicitly - hardly scalable.

With the changes from this PR, one can simply add `exclude: <DOC_SITE_NAME>` to antora-navigator.yml to not include it in that nav group:

```yml
groups:
- root: true
  components: home
- title: Docs by Product
  components: ['*', tcat-server]
  exclude: general
output_file: site-navigation-data.js
```

In a more extreme example, the following antora-navigator.yml would yield the following screenshot:

```yml
groups:
- root: true
  components: home
- title: Docs by Product
  # pull every components, put tcat-server as last, and exclude 3 components
  components: ['*', tcat-server]
  exclude: [data-gateway, general, munit]
- title: Docs by Product 2
  # by definition, pull every components put tcat-server as last, and exclude 2 components
  # in practice, since the previous group already has all the components, those will not be added to this group. Only the 3 components that were previously excluded are available to be picked and 2 of those are excluded here again, therefore, only data-gateway will be added to this group
  components: ['*', tcat-server]
  exclude: [general, munit]
- title: Docs by Product 3
  # Only general and munit remain at this point. Since general is excluded, only munit will be added to this group
  components: ['*', tcat-server]
  exclude: general
 # at the end, general is not included in any groups
output_file: site-navigation-data.js
```

![Screen Shot 2022-08-05 at 3 11 09 PM](https://user-images.githubusercontent.com/10934908/183218032-4a50986f-e95f-480b-9ca3-6962119e8cad.png)

