### PR TITLE
[W-11549560] fix bug

### DIFF
--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -123,7 +123,7 @@
             : 'icon-nav-page-' + component.name + '-' + it.content?.toLowerCase().replace(/ +/g, '-')
           it.iconId = document.getElementById(iconId)
             ? iconId : group.spreadSingleItem
-              ? 'icon-nav-component' : groupIconId
+              ? 'icon-nav-component' : it.iconId
         })
       }
       return groupsAccum

--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -121,7 +121,9 @@
           var iconId = it.url
             ? 'icon-nav-page' + it.url.replace(/(?:\.html|\/)$/, '').replace(/[/#]/g, '-')
             : 'icon-nav-page-' + component.name + '-' + it.content?.toLowerCase().replace(/ +/g, '-')
-          it.iconId = document.getElementById(iconId) ? iconId : 'icon-nav-component'
+          it.iconId = document.getElementById(iconId)
+            ? iconId : group.spreadSingleItem
+              ? 'icon-nav-component' : groupIconId
         })
       }
       return groupsAccum


### PR DESCRIPTION
ref: [W-11549560](https://gus.lightning.force.com/a07EE000013HtpRYAS)

In https://github.com/mulesoft/docs-site-ui/pull/172, a logic is added where if the icon for an item doesn't exist, then automatically apply the muley icon. However, in https://github.com/mulesoft/docs-site-ui/pull/173, if `spreadSingleItem` is not true or not set, then each of the sub-items also receive a Muley icon, which looks rather funny:

![Screen Shot 2022-08-08 at 4 53 28 PM](https://user-images.githubusercontent.com/10934908/183534078-55e601c6-e9e9-41df-b6f3-232a0d7c8d4d.png)

This PR adds a little bit more logic so that Muley icons will only be set if `spreadSingleItem` is set to true. Otherwise, do not assign an icon.