### PR TITLE
[W-11568618] remove languages

### DIFF
--- a/src/partials/footer-content.hbs
+++ b/src/partials/footer-content.hbs
@@ -83,18 +83,12 @@
                 </nav>
                 <div class="language-selector-wrapper sl_opaque">
                     <ul class="language-selection">
-                        <li class="german"><a href="https://www.mulesoft.com/de">Deutsch</a></li>
-                        <li class="english"><a href="https://www.mulesoft.com/">English <sub>Full site</sub></a></li>
-                        <li class="french"><a href="https://www.mulesoft.com/fr">French</a></li>
-                        <li class="japanese"><a href="https://www.mulesoft.com/jp">Japanese</a></li>
-                        <li class="portuguese"><a href="https://www.mulesoft.com/pt">Portuguese</a></li>
+                        <li class="english"><a href="https://docs.mulesoft.com/">English <sub>Full site</sub></a></li>
+                        <li class="japanese"><a href="https://docs.mulesoft.com/jp/">Japanese</a></li>
                     </ul>
                     <ul class="language-selected">
-                        <li class="german"><a href="https://www.mulesoft.com/de">Deutsch</a></li>
-                        <li class="french"><a href="https://www.mulesoft.com/fr">French</a></li>
-                        <li class="japanese"><a href="https://www.mulesoft.com/jp">Japanese</a></li>
-                        <li class="portuguese"><a href="https://www.mulesoft.com/pt">Portuguese</a></li>
-                        <li class="english"><a href="https://www.mulesoft.com/">English <sub>Full site</sub></a></li>
+                        <li class="japanese"><a href="https://docs.mulesoft.com/jp/">Japanese</a></li>
+                        <li class="english"><a href="https://docs.mulesoft.com/">English <sub>Full site</sub></a></li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
ref: [W-11568618](https://gus.lightning.force.com/a07EE000013cuc4YAA)

- remove languages from the footer dropdown that don't have docs available, namely Portuguese, German, and French
- update href links of English and Japanese sites to docs site instead of mulesoft.com