### PR TITLE
[W-11613507] add homeTitle

### DIFF
--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -126,6 +126,7 @@
             ? iconId : group.spreadSingleItem
               ? 'icon-nav-component' : it.iconId
         })
+        if (group.homeTitle) component.title = group.homeTitle
       }
       return groupsAccum
     }, [])


### PR DESCRIPTION
[W-11613507](https://gus.lightning.force.com/a07EE000014KmzLYAS)

add a line which allows using the attribute `homeTitle` to override the name of the "home" icon. Primarily used for the archive site

https://www.loom.com/share/ba7847e3cde9484194e250ac15c327ed