### PR TITLE
[W-10813707] bug fix - exclude dw playground links from blue background when hovered

### DIFF
--- a/src/css/adoc/doc.css
+++ b/src/css/adoc/doc.css
@@ -171,7 +171,7 @@
   }
 
   /* links */
-  & a:not(.button-primary):not(.notice-banner-link) {
+  & a:not(.button-primary):not(.dw-playground-link):not(.notice-banner-link) {
     color: #002196;
 
     &:active,


### PR DESCRIPTION
ref: W-10813707

exclude dataweave playground links from having the blue background when hovered. It wasn't supposed to apply to these buttons

![Screen Shot 2022-09-26 at 3 01 59 PM](https://user-images.githubusercontent.com/10934908/192388707-cb3373fb-53c6-4467-af9f-3f0beeeb69f3.png)
