### PR TITLE
[W-10592499] make TOC items tabbable

### DIFF
--- a/src/css/adoc/admonition-block.css
+++ b/src/css/adoc/admonition-block.css
@@ -9,7 +9,7 @@
   & tbody {
     border: 1px solid var(--aluminum-3);
     border-radius: 2px;
-    color: var(--steel-1);
+    color: var(--steel-2);
     display: block;
     font-size: 14px;
     padding: var(--md) var(--lg) var(--sm);

--- a/src/css/adoc/doc-footer.css
+++ b/src/css/adoc/doc-footer.css
@@ -46,7 +46,7 @@
   }
 
   & .link {
-    color: var(--core-blue-3);
+    color: var(--secondary-navy);
     cursor: pointer;
     font-size: 12px;
     margin-top: var(--md);

--- a/src/css/adoc/doc.css
+++ b/src/css/adoc/doc.css
@@ -279,7 +279,7 @@
   }
 
   & blockquote {
-    color: var(--aluminum-5);
+    color: var(--steel-2);
     margin-left: 0;
   }
 

--- a/src/css/adoc/doc.css
+++ b/src/css/adoc/doc.css
@@ -172,7 +172,7 @@
 
   /* links */
   & a:not(.button-primary):not(.dw-playground-link):not(.notice-banner-link) {
-    color: #002196;
+    color: var(--secondary-navy);
 
     &:active,
     &:focus {

--- a/src/css/components/button.css
+++ b/src/css/components/button.css
@@ -10,13 +10,13 @@
 .button {
   background: var(--tertiary);
   border: 1px solid var(--aluminum-4);
-  color: var(--aluminum-5);
+  color: var(--steel-2);
   height: var(--nav-item-height);
   padding: var(--xs);
 
   &:hover {
-    border-color: var(--aluminum-5);
-    color: var(--steel-1);
+    border-color: var(--steel-2);
+    color: var(--steel-2);
   }
 
   &:focus {

--- a/src/css/components/button.css
+++ b/src/css/components/button.css
@@ -20,18 +20,18 @@
   }
 
   &:focus {
-    border-color: var(--core-blue-3);
-    color: var(--core-blue-3);
+    border-color: var(--secondary-navy);
+    color: var(--secondary-navy);
   }
 
   &:active {
-    border-color: var(--core-blue-3);
-    color: var(--core-blue-3);
+    border-color: var(--secondary-navy);
+    color: var(--secondary-navy);
   }
 }
 
 .button-primary {
-  background: var(--core-blue-3);
+  background: var(--secondary-navy);
   border: 0;
   border-radius: var(--radius);
   color: var(--tertiary);

--- a/src/css/components/card.css
+++ b/src/css/components/card.css
@@ -18,7 +18,7 @@
 
   &:active,
   &:focus {
-    border-color: var(--core-blue-3);
+    border-color: var(--secondary-navy);
     box-shadow: 0 4px 16px rgba(0,162,223,.06), 0 0 0 3px rgba(0,162,223,.38);
     color: var(--steel-3);
   }

--- a/src/css/components/card.css
+++ b/src/css/components/card.css
@@ -2,7 +2,7 @@
   border: 1px solid rgba(0,0,0,.06);
   border-radius: 2px;
   box-shadow: 0 4px 16px rgba(0,0,0,.03);
-  color: var(--steel-2);
+  color: var(--steel-3);
   display: block;
   flex: 1 1 33%;
   flex-direction: column;
@@ -20,7 +20,7 @@
   &:focus {
     border-color: var(--core-blue-3);
     box-shadow: 0 4px 16px rgba(0,162,223,.06), 0 0 0 3px rgba(0,162,223,.38);
-    color: var(--steel-2);
+    color: var(--steel-3);
   }
 
   & + .card {

--- a/src/css/components/github.css
+++ b/src/css/components/github.css
@@ -5,7 +5,7 @@
   text-decoration: none;
 
   &:focus {
-    border-color: var(--core-blue-3);
+    border-color: var(--secondary-navy);
     box-shadow: 0 0 0 3px rgba(0,162,223,.25);
     outline: 0;
   }

--- a/src/css/components/popover.css
+++ b/src/css/components/popover.css
@@ -38,7 +38,7 @@
 
 /* popover-level */
 .tippy-popper .popover-theme.popover-level-theme {
-  color: var(--steel-2);
+  color: var(--steel-3);
   font-size: 12px;
   padding: 0 var(--md);
 }

--- a/src/css/components/select.css
+++ b/src/css/components/select.css
@@ -26,7 +26,7 @@
   transition: box-shadow var(--transition-speed-sm) var(--transition-timing);
 
   &:focus {
-    border-color: var(--core-blue-3);
+    border-color: var(--secondary-navy);
     box-shadow: 0 0 0 3px rgba(0,162,223,.25);
     outline: 0;
   }

--- a/src/css/globals/global.css
+++ b/src/css/globals/global.css
@@ -18,7 +18,7 @@ html {
 
 body {
   background: #fefefe;
-  color: var(--steel-2);
+  color: var(--steel-3);
   font-family: var(--sans-serif);
   font-size: 16px;
   line-height: 1.6;

--- a/src/css/globals/reset.css
+++ b/src/css/globals/reset.css
@@ -30,7 +30,7 @@ select {
 
   /* placeholder */
   &::placeholder {
-    color: var(--steel-2);
+    color: var(--steel-3);
   }
 
   /* checkbox radius */

--- a/src/css/globals/reset.css
+++ b/src/css/globals/reset.css
@@ -23,7 +23,7 @@ select {
   /* focus state */
   &.focus,
   &:focus {
-    border-color: var(--core-blue-3);
+    border-color: var(--secondary-navy);
     box-shadow: 0 0 0 3px rgba(0,162,223,.25);
     outline: 0;
   }
@@ -47,7 +47,7 @@ textarea {
 button {
   &.focus,
   &:focus {
-    border-color: var(--core-blue-3);
+    border-color: var(--secondary-navy);
     box-shadow: 0 0 0 3px rgba(0,162,223,.25);
     outline: 0;
   }

--- a/src/css/globals/typography.css
+++ b/src/css/globals/typography.css
@@ -91,12 +91,9 @@ h6 {
 .link {
   color: var(--steel-3);
 
-  &:hover {
-    color: var(--steel-4);
-  }
-
+  &:active,
   &:focus,
-  &:active {
-    color: var(--core-blue-3);
+  &:hover {
+    color: var(--secondary-navy);
   }
 }

--- a/src/css/globals/typography.css
+++ b/src/css/globals/typography.css
@@ -89,7 +89,7 @@ h6 {
 
 /* links */
 .link {
-  color: var(--steel-2);
+  color: var(--steel-3);
 
   &:hover {
     color: var(--steel-4);

--- a/src/css/globals/vars.css
+++ b/src/css/globals/vars.css
@@ -1,5 +1,6 @@
 :root {
   /* colors */
+  --secondary-navy: #002196;
   --core-blue-0: #f2fafd;
   --core-blue-1: #abe2f5;
   --core-blue-2: #48c1ed;

--- a/src/css/pages/connector-article.css
+++ b/src/css/pages/connector-article.css
@@ -54,7 +54,7 @@
 
   & .col:first-child,
   & .categories-header {
-    color: var(--aluminum-5);
+    color: var(--steel-2);
     padding-right: var(--sm);
   }
 
@@ -119,7 +119,7 @@
   }
 
   & .icon-help {
-    fill: var(--aluminum-5);
+    fill: var(--steel-2);
     padding: 2px;
   }
 }

--- a/src/css/pages/connector-article.css
+++ b/src/css/pages/connector-article.css
@@ -9,7 +9,7 @@
   }
 
   & .link {
-    color: var(--core-blue-3);
+    color: var(--secondary-navy);
     text-decoration: none;
 
     &:hover .icon-back-arrow,
@@ -95,7 +95,7 @@
     &:focus,
     &:active {
       background: #e2f8ff; /* yet another blue */
-      color: var(--core-blue-3);
+      color: var(--secondary-navy);
     }
 
     & .icon-external {

--- a/src/css/pages/connector-home.css
+++ b/src/css/pages/connector-home.css
@@ -49,7 +49,7 @@
   /* smaller featured items */
   & .featured-link {
     align-items: center;
-    color: var(--steel-2);
+    color: var(--steel-3);
     display: flex;
     font-size: 15px;
     font-weight: var(--weight-bold);

--- a/src/css/pages/connector-home.css
+++ b/src/css/pages/connector-home.css
@@ -65,7 +65,7 @@
     }
 
     &:focus {
-      color: var(--core-blue-3);
+      color: var(--secondary-navy);
       outline: 0;
     }
 

--- a/src/css/pages/connector.css
+++ b/src/css/pages/connector.css
@@ -20,7 +20,7 @@
 
 .popover-connector-menu,
 .popover-connector-version {
-  color: var(--steel-2);
+  color: var(--steel-3);
   cursor: default;
   font-size: 14px;
 

--- a/src/css/pages/connector.css
+++ b/src/css/pages/connector.css
@@ -48,7 +48,7 @@
     &:focus,
     &:active {
       background: #e2f8ff; /* yet another blue */
-      color: var(--core-blue-3);
+      color: var(--secondary-navy);
     }
   }
 

--- a/src/css/specific/gdpr.css
+++ b/src/css/specific/gdpr.css
@@ -20,7 +20,7 @@
   }
 
   & .link {
-    color: var(--core-blue-3);
+    color: var(--secondary-navy);
   }
 }
 

--- a/src/css/specific/nav.css
+++ b/src/css/specific/nav.css
@@ -135,7 +135,7 @@ svg.nav-icon {
     }
     &.is-active > .nav-title .nav-text,
     & > [aria-current=page] {
-      color: var(--core-blue-3);
+      color: var(--secondary-navy);
     }
     &.is-active {
       & > .nav-title .nav-icon {
@@ -218,8 +218,8 @@ svg.nav-icon {
   &:focus,
   &:active {
     background: var(--tertiary);
-    border-color: var(--core-blue-3);
-    color: var(--core-blue-3);
+    border-color: var(--secondary-navy);
+    color: var(--secondary-navy);
   }
 
   & svg.nav-version-icon {
@@ -280,7 +280,7 @@ svg.nav-icon {
 
     &:active {
       background: #e2f8ff;
-      color: var(--core-blue-3);
+      color: var(--secondary-navy);
     }
   }
 }

--- a/src/css/specific/nav.css
+++ b/src/css/specific/nav.css
@@ -272,9 +272,9 @@ svg.nav-icon {
   }
 
   & .nav-version-option {
+    background: none;
     border: 0;
     border-radius: 2px;
-    background: none;
     cursor: pointer;
     text-align: left;
     width: 100%;

--- a/src/css/specific/nav.css
+++ b/src/css/specific/nav.css
@@ -257,7 +257,9 @@ svg.nav-icon {
     transition: opacity var(--transition-speed-sm) var(--transition-timing), transform var(--transition-speed-sm) var(--transition-timing), max-height 0s var(--transition-speed-sm);
   }
 
-  & li {
+  & button,
+  & span {
+    display: list-item;
     padding: var(--xs) var(--sm);
   }
 
@@ -270,8 +272,12 @@ svg.nav-icon {
   }
 
   & .nav-version-option {
+    border: 0;
     border-radius: 2px;
+    background: none;
     cursor: pointer;
+    text-align: left;
+    width: 100%;
 
     &:hover,
     &:focus {

--- a/src/css/specific/nav.css
+++ b/src/css/specific/nav.css
@@ -1,7 +1,7 @@
 .nav {
   background: var(--tertiary);
   box-shadow: 1px 0 0 var(--aluminum-3), 3px 0 15px rgb(0 0 0 / .025);
-  color: var(--steel-2);
+  color: var(--steel-3);
   display: flex;
   flex-direction: column;
   font-size: 14px;
@@ -30,8 +30,8 @@
     z-index: inherit;
     & button {
       align-items: center;
-      border-color: var(--steel-2);
-      color: var(--steel-2);
+      border-color: var(--steel-3);
+      color: var(--steel-3);
       display: flex;
       font-weight: var(--weight-bold);
       line-height: 1;
@@ -211,8 +211,8 @@ svg.nav-icon {
   transform: translateY(.075em);
 
   &:hover {
-    border-color: var(--aluminum-5);
-    color: var(--steel-1);
+    border-color: var(--steel-2);
+    color: var(--steel-2);
   }
 
   &:focus,

--- a/src/css/specific/notice-banner.css
+++ b/src/css/specific/notice-banner.css
@@ -15,7 +15,7 @@
     }
 
     & a {
-      color: #002196;
+      color: var(--secondary-navy);
       &:hover {
         background-color: #e8f8ff;
         border-radius: 5px;
@@ -33,7 +33,7 @@
       }
 
       &:visited {
-        color: #002196;
+        color: var(--secondary-navy);
       }
     }
   }

--- a/src/css/specific/toc.css
+++ b/src/css/specific/toc.css
@@ -26,7 +26,7 @@
 
 .toc-menu a {
   border-left: 3px solid var(--aluminum-3);
-  color: var(--aluminum-5);
+  color: var(--steel-2);
   display: block;
   font-size: 12px;
   padding: var(--xs) var(--sm);
@@ -36,12 +36,12 @@
   &:focus,
   &:active {
     border-left-color: var(--aluminum-4);
-    color: var(--steel-1);
+    color: var(--steel-2);
   }
 
   &.is-active {
     border-color: var(--core-blue-3);
-    color: var(--steel-1);
+    color: var(--steel-2);
   }
 
   & code {

--- a/src/css/specific/toc.css
+++ b/src/css/specific/toc.css
@@ -36,12 +36,12 @@
   &:focus,
   &:active {
     border-left-color: var(--aluminum-4);
-    color: var(--steel-2);
+    color: var(--steel-4);
   }
 
   &.is-active {
-    border-color: var(--core-blue-3);
-    color: var(--steel-2);
+    border-color: var(--secondary-navy);
+    color: var(--steel-4);
   }
 
   & code {

--- a/src/css/vendor/coveo.css
+++ b/src/css/vendor/coveo.css
@@ -1,6 +1,6 @@
 /* override coveo defaults */
 .CoveoSearchInterface.CoveoSearchInterface {
-  color: var(--steel-2);
+  color: var(--steel-3);
   font-family: var(--sans-serif);
   font-size: 16px;
 }
@@ -21,7 +21,7 @@
     background-color: var(--aluminum-1);
     border: none;
     cursor: pointer;
-    fill: var(--steel-2);
+    fill: var(--steel-3);
     height: var(--xxl);
     margin-left: var(--md);
     padding: var(--xs);
@@ -73,7 +73,7 @@
     border: 1px solid #67768b;
     border-radius: 4px;
     box-shadow: inset 0 0 6px rgba(0,0,0,.025);
-    color: var(--steel-2);
+    color: var(--steel-3);
     transition: box-shadow var(--transition-speed-sm) var(--transition-timing);
     width: 74%;
 
@@ -94,7 +94,7 @@
         text-indent: 0;
 
         &::placeholder {
-          color: var(--steel-2);
+          color: var(--steel-3);
         }
       }
     }
@@ -144,7 +144,7 @@
   & .magic-box-clear {
     align-items: center;
     background: none;
-    color: var(--steel-2);
+    color: var(--steel-3);
     display: flex;
     justify-content: center;
     opacity: 0;
@@ -154,7 +154,7 @@
 
     &:hover,
     &:focus {
-      color: var(--aluminum-5);
+      color: var(--steel-2);
     }
 
     &::before {
@@ -185,7 +185,7 @@
 
   & .magic-box-suggestion {
     border-top: 0;
-    color: var(--steel-2);
+    color: var(--steel-3);
     padding: var(--sm);
 
     &:hover,
@@ -220,7 +220,7 @@
 
   /* facet things */
   & .facet-heading {
-    color: var(--steel-2);
+    color: var(--steel-3);
     font-family: var(--heading);
     font-size: 14px;
     font-weight: var(--weight-bold);
@@ -282,7 +282,7 @@
     padding: 0;
 
     & .coveo-facet-header-title {
-      color: var(--steel-2);
+      color: var(--steel-3);
       font-size: 12px;
     }
 
@@ -436,7 +436,7 @@
     }
 
     & .CoveoResultLink {
-      color: var(--steel-2);
+      color: var(--steel-3);
       font-family: var(--heading);
       font-size: 14px;
       font-weight: var(--weight-bold);
@@ -525,7 +525,7 @@
 
   & a {
     align-items: center;
-    color: var(--aluminum-5);
+    color: var(--steel-2);
     display: flex;
     font-size: 13px;
 
@@ -641,6 +641,6 @@
 }
 
 .tip-text {
-  color: var(--steel-2);
+  color: var(--steel-3);
   font-size: 12px;
 }

--- a/src/css/vendor/coveo.css
+++ b/src/css/vendor/coveo.css
@@ -80,7 +80,7 @@
     /* focus state */
     &.magic-box-hasFocus {
       background: var(--tertiary);
-      border-color: var(--core-blue-3);
+      border-color: var(--secondary-navy);
       box-shadow: 0 0 0 3px rgba(0,162,223,.25);
       outline: 0;
     }
@@ -136,7 +136,7 @@
     }
 
     & .coveo-search-button-loading-svg {
-      color: var(--core-blue-3);
+      color: var(--secondary-navy);
     }
   }
 
@@ -340,7 +340,7 @@
   & .coveo-facet-more,
   & .coveo-facet-less {
     background: none;
-    color: var(--core-blue-3);
+    color: var(--secondary-navy);
     font-size: 12px;
     text-align: left;
 
@@ -447,7 +447,7 @@
 
       &:hover,
       &:focus {
-        color: var(--core-blue-3);
+        color: var(--secondary-navy);
       }
     }
   }
@@ -532,7 +532,7 @@
     &:hover,
     &:focus,
     &:active {
-      color: var(--core-blue-3);
+      color: var(--secondary-navy);
     }
   }
 

--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -227,7 +227,12 @@
         toggleNav.call(navItem, componentData, false, page)
         e.preventDefault()
       })
-      navLink.addEventListener('focus', toggleNav.bind(navItem, componentData, false, page))
+      navLink.addEventListener('keydown', function (e) {
+        if (isSpaceOrEnterKey(e.keyCode)) {
+          toggleNav.call(navItem, componentData, false, page)
+          e.preventDefault()
+        }
+      })
     }
     if (componentData.iconId) {
       navTitle.classList.add('has-icon')
@@ -280,7 +285,7 @@
       )
       navVersionOption.setAttribute('tabindex', '-1')
       navVersionOption.addEventListener('keydown', function (e) {
-        if (e.keyCode === 13 || e.keyCode === 32) {
+        if (isSpaceOrEnterKey(e.keyCode)) {
           setTabIndexForVersions()
         }
       })
@@ -294,7 +299,7 @@
       e.preventDefault()
     })
     navVersionButton.addEventListener('keydown', function (e) {
-      if (e.keyCode === 13 || e.keyCode === 32) {
+      if (isSpaceOrEnterKey(e.keyCode)) {
         toggleVersionMenu.call(navVersionMenu)
         e.preventDefault()
       }
@@ -308,6 +313,10 @@
       autoCloseVersionDropdown(navVersionMenu)
     })
     return navVersionDropdown
+  }
+
+  function isSpaceOrEnterKey (keyCode) {
+    return [13, 32].includes(keyCode)
   }
 
   function autoCloseVersionDropdown (navVersionMenu) {

--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -265,7 +265,9 @@
         if (versionData === currentVersionData) {
           navVersionMenu.appendChild(createElement('span.nav-version-label', 'Current version'))
         } else if (versionData.prerelease) {
-          if (!lastVersionData) navVersionMenu.appendChild(createElement('span.nav-version-label', 'Prerelease versions'))
+          if (!lastVersionData) {
+            navVersionMenu.appendChild(createElement('span.nav-version-label', 'Prerelease versions'))
+          }
         } else if (lastVersionData === currentVersionData) {
           navVersionMenu.appendChild(createElement('span.nav-version-label', 'Previous versions'))
         }
@@ -318,10 +320,10 @@
   }
 
   function setTabIndexForVersions () {
-    setTimeout( function () {
-      var tabIndex = document.querySelector('.is-active') ? 0 : -1
+    setTimeout(function () {
+      var tabIndex = document.querySelector('.nav-version-menu.is-active') ? 0 : -1
       const navVersionOptions = document.querySelectorAll('.nav-version-option')
-      navVersionOptions.forEach(function(navVersionOption){
+      navVersionOptions.forEach(function (navVersionOption) {
         navVersionOption.setAttribute('tabindex', tabIndex)
       })
     }, 200)
@@ -498,15 +500,6 @@
       menu.classList.add('is-clipped')
       menu.style.maxHeight = 0
       menu.classList.remove('is-active')
-      return true
-    }
-  }
-
-  function unhideVersionMenu (menu, force) {
-    if (force || !menu.classList.contains('is-active')) {
-      menu.classList.remove('is-clipped')
-      menu.style.maxHeight = null
-      menu.classList.add('is-active')
       return true
     }
   }

--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -268,8 +268,18 @@
         }
       }
       var versionDataset = { version: versionData.version }
+      var navVersionOption = createElement(
+        'li.nav-version-option',
+        { dataset: versionDataset },
+        versionData.displayVersion
+      )
+      navVersionOption.setAttribute('tabindex', '0')
+      navVersionOption.setAttribute('role', 'button')
+      navVersionOption.addEventListener('keydown', function (e) {
+        if (e.keyCode === 'enter') selectVersion.bind(navVersionMenu, navItem, componentData, page)
+      })
       navVersionMenu
-        .appendChild(createElement('li.nav-version-option', { dataset: versionDataset }, versionData.displayVersion))
+        .appendChild(navVersionOption)
         .addEventListener('click', selectVersion.bind(navVersionMenu, navItem, componentData, page))
       return versionData
     }, undefined)

--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -215,6 +215,7 @@
   function createNavTitle (navItem, componentData, page) {
     var navTitle = createElement('.nav-title')
     var navLink = createElement('a.link.nav-text', componentData.title)
+    navLink.setAttribute('tabindex', '0')
     if (componentData.name === 'home') {
       var homeUrl = componentData.nav.url
       if ((navLink.href = relativize(homeUrl)) === relativize(page.url)) {
@@ -223,6 +224,7 @@
       }
     } else {
       navLink.addEventListener('click', toggleNav.bind(navItem, componentData, false, page))
+      navLink.addEventListener('focus', toggleNav.bind(navItem, componentData, false, page))
     }
     if (componentData.iconId) {
       navTitle.classList.add('has-icon')

--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -223,7 +223,10 @@
         navLink.setAttribute('aria-current', 'page')
       }
     } else {
-      navLink.addEventListener('click', toggleNav.bind(navItem, componentData, false, page))
+      navLink.addEventListener('mousedown', function (e) {
+        toggleNav.call(navItem, componentData, false, page)
+        e.preventDefault()
+      })
       navLink.addEventListener('focus', toggleNav.bind(navItem, componentData, false, page))
     }
     if (componentData.iconId) {
@@ -256,37 +259,72 @@
     if (page.navVersionIconId) {
       navVersionButton.appendChild(createSvgElement('.icon.nav-version-icon', '#' + page.navVersionIconId))
     }
-    var navVersionMenu = createElement('ul.nav-version-menu')
+    var navVersionMenu = createElement('div.nav-version-menu')
     versions.reduce(function (lastVersionData, versionData) {
       if (!isArchiveSite()) {
         if (versionData === currentVersionData) {
-          navVersionMenu.appendChild(createElement('li.nav-version-label', 'Current version'))
+          navVersionMenu.appendChild(createElement('span.nav-version-label', 'Current version'))
         } else if (versionData.prerelease) {
-          if (!lastVersionData) navVersionMenu.appendChild(createElement('li.nav-version-label', 'Prerelease versions'))
+          if (!lastVersionData) navVersionMenu.appendChild(createElement('span.nav-version-label', 'Prerelease versions'))
         } else if (lastVersionData === currentVersionData) {
-          navVersionMenu.appendChild(createElement('li.nav-version-label', 'Previous versions'))
+          navVersionMenu.appendChild(createElement('span.nav-version-label', 'Previous versions'))
         }
       }
       var versionDataset = { version: versionData.version }
       var navVersionOption = createElement(
-        'li.nav-version-option',
+        'button.nav-version-option',
         { dataset: versionDataset },
         versionData.displayVersion
       )
-      navVersionOption.setAttribute('tabindex', '0')
-      navVersionOption.setAttribute('role', 'button')
+      navVersionOption.setAttribute('tabindex', '-1')
       navVersionOption.addEventListener('keydown', function (e) {
-        if (e.keyCode === 'enter') selectVersion.bind(navVersionMenu, navItem, componentData, page)
+        if (e.keyCode === 13 || e.keyCode === 32) {
+          setTabIndexForVersions()
+        }
       })
       navVersionMenu
         .appendChild(navVersionOption)
         .addEventListener('click', selectVersion.bind(navVersionMenu, navItem, componentData, page))
       return versionData
     }, undefined)
-    navVersionButton.addEventListener('click', toggleVersionMenu.bind(navVersionMenu))
+    navVersionButton.addEventListener('mousedown', function (e) {
+      toggleVersionMenu.call(navVersionMenu)
+      e.preventDefault()
+    })
+    navVersionButton.addEventListener('keydown', function (e) {
+      if (e.keyCode === 13 || e.keyCode === 32) {
+        toggleVersionMenu.call(navVersionMenu)
+        e.preventDefault()
+      }
+    })
+    navVersionButton.addEventListener('blur', function (e) {
+      autoCloseVersionDropdown(navVersionMenu)
+    })
     navVersionDropdown.appendChild(navVersionButton)
     navVersionDropdown.appendChild(navVersionMenu)
+    navVersionMenu.lastChild.addEventListener('blur', function (e) {
+      autoCloseVersionDropdown(navVersionMenu)
+    })
     return navVersionDropdown
+  }
+
+  function autoCloseVersionDropdown (navVersionMenu) {
+    setTimeout(function () {
+      if (!navVersionMenu.contains(document.activeElement)) {
+        closeVersionMenu()
+        setTabIndexForVersions()
+      }
+    }, 100)
+  }
+
+  function setTabIndexForVersions () {
+    setTimeout( function () {
+      var tabIndex = document.querySelector('.is-active') ? 0 : -1
+      const navVersionOptions = document.querySelectorAll('.nav-version-option')
+      navVersionOptions.forEach(function(navVersionOption){
+        navVersionOption.setAttribute('tabindex', tabIndex)
+      })
+    }, 200)
   }
 
   function createNavList (navEntryData, page, version, lineage) {
@@ -442,6 +480,7 @@
     this.classList.remove('is-clipped')
     this.style.maxHeight = height
     this.classList.add('is-active')
+    setTabIndexForVersions()
   }
 
   function getNavGroupsBottom () {
@@ -459,6 +498,15 @@
       menu.classList.add('is-clipped')
       menu.style.maxHeight = 0
       menu.classList.remove('is-active')
+      return true
+    }
+  }
+
+  function unhideVersionMenu (menu, force) {
+    if (force || !menu.classList.contains('is-active')) {
+      menu.classList.remove('is-clipped')
+      menu.style.maxHeight = null
+      menu.classList.add('is-active')
       return true
     }
   }


### PR DESCRIPTION
ref: W-10592499, W-10813743

# left nav (TOC) items
- make all actionable TOC items reachable by the keyboard TAB keys
- all expandable TOC items can be expanded or collapsed via mouse clicks and keyboard enter and space keys
- ~~when the nav group items are focused, expand them automatically so keyboard users can access the content within~~ (focus is easy to cause unwanted effects and makes the code messier)

note: although in the GUS ticket above, it stated that CSS is possibly in play to block the `<a>` elements to be focusable, but I can't find that CSS attribute. So tabindex is used instead

# increase contrast
- increase contrast for some of the lighter-shaded elements so they pass the contrast ratio

https://www.loom.com/share/18a1f563249245649dd87160823053a9
