### PR TITLE
[W-11799442] fix archive site's home icon name

### DIFF
--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -604,8 +604,7 @@
   }
 
   function isArchiveSite () {
-    return true
-    // return window.location.host.includes('archive')
+    return window.location.host.includes('archive')
   }
 
   buildNav(extractNavData(window), document.querySelector('.nav'), getPage())

--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -129,7 +129,6 @@
               ? 'icon-nav-component'
               : it.iconId
         })
-        if (group.homeTitle) component.title = group.homeTitle
       }
       return groupsAccum
     }, [])
@@ -143,7 +142,7 @@
     if (found) return components
     return components.concat({
       name: 'home',
-      title: 'Home',
+      title: setTitle('Home'),
       versions: [{ version: '', sets: [{ content: 'Home', url: homeUrl }] }],
     })
   }
@@ -538,8 +537,13 @@
     return Array.isArray(val) ? val : [val]
   }
 
+  function setTitle (title) {
+    return isArchiveSite() ? `Archive ${title}` : title
+  }
+
   function isArchiveSite () {
-    return window.location.host.includes('archive')
+    return true
+    // return window.location.host.includes('archive')
   }
 
   buildNav(extractNavData(window), document.querySelector('.nav'), getPage())


### PR DESCRIPTION
ref: W-11799442

fix the issue where the archive site's Home nav item has the name "Home" when it should have been "Archive Home" instead.

![Screen Shot 2022-09-29 at 4 28 07 PM](https://user-images.githubusercontent.com/10934908/193159547-b89f4ee6-cd2a-451f-afd3-8dc8db9e6429.png)

Note that this is impossible to test locally because the key function, `isArchiveSite()`, looks for the base URL to modify the name, and you can't set that in a local setting.. 