### PR TITLE
[W-11836509] remove GitHub button from archive site

### DIFF
--- a/src/css/specific/nav.css
+++ b/src/css/specific/nav.css
@@ -275,6 +275,7 @@ svg.nav-icon {
     background: none;
     border: 0;
     border-radius: 2px;
+    color: var(--steel-3);
     cursor: pointer;
     text-align: left;
     width: 100%;

--- a/src/partials/github.hbs
+++ b/src/partials/github.hbs
@@ -1,4 +1,4 @@
-{{#if (or (and page.fileUri (not env.CI)) (and page.editUrl (not page.origin.private))) }}
+{{#if (and (or (and page.fileUri (not env.CI)) (and page.editUrl (not page.origin.private))) (ne (site-profile) "archive")) }}
     <a target="_blank" class="flex shrink align-center button button-edit js-github" 
     {{#if (and page.fileUri (not env.CI))}}
     href="{{page.fileUri}}"

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -3,7 +3,7 @@
     <div></div>
   </div>
   <div class="ms-com-helmet">
-    <div class="helmet-inside"> <a href="https://www.salesforce.com/" target="_blank" onclick="getGATracker().send('event', 'NAV', 'NavClick', 'Helmet - Salesforce link');"> <img src="https://www.mulesoft.com/sites/default/files/cmm_files/salesforce-logo.svg" alt="salesforce"></a> <a href="https://www.salesforce.com/plus/experience/Dreamforce_2022/series/Integration?utm_source=mulesoft&amp;utm_medium=referral&amp;utm_campaign=dreamforce-helmet" class="helmet-featured" target="_blank" onclick="getGATracker().send('event', 'NAV', 'NavClick', 'Helmet - Dreamforce campaign');">Replay Dreamforce</a></div>
+    <div class="helmet-inside"> <a href="https://www.salesforce.com/" target="_blank" onclick="getGATracker().send('event', 'NAV', 'NavClick', 'Helmet - Salesforce link');"> <img src="https://www.mulesoft.com/sites/default/files/cmm_files/salesforce-logo.svg" alt="salesforce"></a> <a href="https://connect.mulesoft.com/?utm_source=mulesoft&amp;utm_medium=referral&amp;utm_campaign=connect-helmet" target="_blank" class="helmet-featured" onclick="getGATracker().send('event', 'NAV', 'NavClick', 'Helmet - Dreamforce campaign');">Replay CONNECT now</a></div>
   </div>
   <header class="ms-com-header desktop-header">
     <div class="header-overlay"></div>


### PR DESCRIPTION
ref: W-11836509

- exclude GitHub button rom the archive site only
- update header content
- force versions to have the dark gray color (I saw dark blue once once while reading the docs site on mobile)

## how to test

1. run `gulp bundle` on this branch to create a local ui-bundle.zip
2. open docs-site-playbook, switch to the archive branch
3. [perform a local build](https://confluence.internal.salesforce.com/display/MTDT/Local+Build+Quick-Ref) using the local UI bundle. The archive site should not have the GitHub button on any of the pages
4. still on docs-site-playbook, switch to the default branch (m*ster)
5. repeat step 3 to perform a local build (with a smaller custom playbook to save time). The site should have the GitHub button on most of the pages