### PR TITLE
[W-11848524] fix focus border issue

### DIFF
--- a/src/css/specific/nav.css
+++ b/src/css/specific/nav.css
@@ -52,15 +52,14 @@
 
 .nav-text {
   display: flex;
-
-  &:focus-visible {
-    border-radius: var(--radius);
-    outline: 2px solid #888;
-  }
 }
 
 a.nav-text {
   text-decoration: none;
+  &:focus {
+    border-radius: var(--radius);
+    outline: 2px solid #888;
+  }
 }
 
 a.nav-text:not([href]),

--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -300,6 +300,7 @@
     navVersionButton.addEventListener('keydown', function (e) {
       if (isSpaceOrEnterKey(e.keyCode)) {
         toggleVersionMenu.call(navVersionMenu)
+        setTabIndexForVersions()
         e.preventDefault()
       }
     })

--- a/src/partials/header-content.hbs
+++ b/src/partials/header-content.hbs
@@ -3,7 +3,7 @@
     <div></div>
   </div>
   <div class="ms-com-helmet">
-    <div class="helmet-inside"> <a href="https://www.salesforce.com/" target="_blank" onclick="getGATracker().send('event', 'NAV', 'NavClick', 'Helmet - Salesforce link');"> <img src="https://www.mulesoft.com/sites/default/files/cmm_files/salesforce-logo.svg" alt="salesforce"></a> <a href="https://www.salesforce.com/plus/experience/Dreamforce_2022/series/Integration?utm_source=mulesoft&amp;utm_medium=referral&amp;utm_campaign=dreamforce-helmet" class="helmet-featured" target="_blank" onclick="getGATracker().send('event', 'NAV', 'NavClick', 'Helmet - Dreamforce campaign');">Replay Dreamforce</a></div>
+    <div class="helmet-inside"> <a href="https://www.salesforce.com/" target="_blank" onclick="getGATracker().send('event', 'NAV', 'NavClick', 'Helmet - Salesforce link');"> <img src="https://www.mulesoft.com/sites/default/files/cmm_files/salesforce-logo.svg" alt="salesforce"></a> <a href="https://connect.mulesoft.com/?utm_source=mulesoft&amp;utm_medium=referral&amp;utm_campaign=connect-helmet" target="_blank" class="helmet-featured" onclick="getGATracker().send('event', 'NAV', 'NavClick', 'Helmet - Dreamforce campaign');">Replay CONNECT now</a></div>
   </div>
   <header class="ms-com-header desktop-header">
     <div class="header-overlay"></div>


### PR DESCRIPTION
ref: [W-11848524](https://gus.lightning.force.com/a07EE000017ppAhYAI)

- fix a bug where when focusing on a nav item in the left nav tree under "Docs by Product", the border does not show up. I believe this is because the CSS adds a border for the element when it is in the **focus-visible** state but not in the **focus** state, which causes different web browsers (including browsers with different versions and configurations) to interpret it differently.
- fix a minor bug when focusing on the nav version selector button, pressing the enter key twice (once to expand the menu, once to collapse it back) will not reset the versions' tabindex to -1, causing subsequent TABs to focus on the hidden versions. This is remediated by adding an additional check to reset the tabindex, in case the first check was too quick.
- update header 