### PR TITLE
[W-10723677] update callout icons to match those in images

### DIFF
--- a/src/css/adoc/doc.css
+++ b/src/css/adoc/doc.css
@@ -18,13 +18,13 @@
 
   /* numbered callouts from codeblocks */
   & .conum {
-    background: var(--tertiary);
-    border: 1px solid var(--aluminum-3);
-    border-radius: 4px;
+    background: #1a5492;
+    border-radius: 10px;
+    color: white;
     font-family: var(--sans-serif);
     font-size: 12px;
     font-style: normal;
-    font-weight: --weight-bold;
+    font-weight: var(--weight-bold);
     padding: 0 5px;
 
     &::after {


### PR DESCRIPTION
ref: [W-10723677](https://gus.lightning.force.com/a07EE00000podylYAA)

Make the callout icons look like the annotation circles in the images:

![Screen Shot 2022-10-05 at 9 01 21 AM](https://user-images.githubusercontent.com/10934908/194108083-6fa30c33-725f-40a4-848e-a7348d2b5acd.png)

