### PR TITLE
[W-10592536] add current version indicator + notice banner close button

### DIFF
--- a/gulp.d/tasks/build.js
+++ b/gulp.d/tasks/build.js
@@ -74,9 +74,12 @@ module.exports = (src, dest, preview) => () => {
       .pipe(buffer())
       .pipe(uglify()),
     vfs
-      .src([require.resolve('popper.js/dist/umd/popper.min.js'), require.resolve('tippy.js/umd/index.min.js')], opts)
+      .src(
+        [require.resolve('@popperjs/core/dist/umd/popper.min.js'), require.resolve('tippy.js/dist/tippy.umd.min.js')],
+        opts
+      )
       .pipe(
-        map((file, enc, next) => {
+        map((file, _enc, next) => {
           file.contents = Buffer.from(file.contents.toString().replace(/\n\/\/# sourceMappingURL=.*/, ''))
           next(null, file)
         })

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "stylelint-config-standard": "~20.0",
         "stylelint-order": "~4.1",
         "through2": "~3.0",
-        "tippy.js": "~4.3",
+        "tippy.js": "6.3.7",
         "typeface-open-sans": "0.0.75",
         "vinyl-buffer": "~1.0",
         "vinyl-fs": "~3.0"
@@ -733,6 +733,16 @@
       "dev": true,
       "dependencies": {
         "@octokit/openapi-types": "^12.11.0"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -11502,17 +11512,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -16010,12 +16009,12 @@
       }
     },
     "node_modules/tippy.js": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-4.3.5.tgz",
-      "integrity": "sha512-NDq3efte8nGK6BOJ1dDN1/WelAwfmh3UtIYXXck6+SxLzbIQNZE/cmRSnwScZ/FyiKdIcvFHvYUgqmoGx8CcyA==",
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
       "dev": true,
       "dependencies": {
-        "popper.js": "^1.14.7"
+        "@popperjs/core": "^2.9.0"
       }
     },
     "node_modules/tlds": {
@@ -17948,6 +17947,12 @@
       "requires": {
         "@octokit/openapi-types": "^12.11.0"
       }
+    },
+    "@popperjs/core": {
+      "version": "2.11.6",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
+      "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
+      "dev": true
     },
     "@sindresorhus/is": {
       "version": "0.7.0",
@@ -26568,12 +26573,6 @@
         "irregular-plurals": "^2.0.0"
       }
     },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "dev": true
-    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
@@ -30232,12 +30231,12 @@
       }
     },
     "tippy.js": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-4.3.5.tgz",
-      "integrity": "sha512-NDq3efte8nGK6BOJ1dDN1/WelAwfmh3UtIYXXck6+SxLzbIQNZE/cmRSnwScZ/FyiKdIcvFHvYUgqmoGx8CcyA==",
+      "version": "6.3.7",
+      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
+      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
       "dev": true,
       "requires": {
-        "popper.js": "^1.14.7"
+        "@popperjs/core": "^2.9.0"
       }
     },
     "tlds": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "stylelint-config-standard": "~20.0",
     "stylelint-order": "~4.1",
     "through2": "~3.0",
-    "tippy.js": "~4.3",
+    "tippy.js": "6.3.7",
     "typeface-open-sans": "0.0.75",
     "vinyl-buffer": "~1.0",
     "vinyl-fs": "~3.0"

--- a/src/css/adoc/doc.css
+++ b/src/css/adoc/doc.css
@@ -100,7 +100,6 @@
   }
 
   & .anchor {
-    display: inline-block;
     float: right;
     height: var(--lg);
     opacity: 0;

--- a/src/css/components/popover.css
+++ b/src/css/components/popover.css
@@ -38,7 +38,71 @@
 
 /* popover-level */
 .tippy-popper .popover-theme.popover-level-theme {
+  background: #032d61;
   color: var(--steel-3);
   font-size: 12px;
   padding: 0 var(--md);
+}
+
+.tippy-box[data-theme~="current-version-popover"] > .tippy-svg-arrow > svg {
+  fill: #032d61;
+}
+
+.tippy-box[data-theme~="current-version-popover"] {
+  background: var(--secondary-navy);
+  color: white;
+  font-size: 11px;
+  padding: 10px;
+}
+
+.tippy-box[data-placement^="top"] > .tippy-svg-arrow {
+  bottom: 0;
+}
+
+.tippy-box[data-placement^="top"] > .tippy-svg-arrow::after,
+.tippy-box[data-placement^="top"] > .tippy-svg-arrow > svg {
+  top: 16px;
+  transform: rotate(180deg);
+}
+
+.tippy-box[data-placement^="bottom"] > .tippy-svg-arrow {
+  top: 0;
+}
+
+.tippy-box[data-placement^="bottom"] > .tippy-svg-arrow > svg {
+  bottom: 16px;
+}
+
+.tippy-box[data-placement^="left"] > .tippy-svg-arrow {
+  right: 0;
+}
+
+.tippy-box[data-placement^="left"] > .tippy-svg-arrow::after,
+.tippy-box[data-placement^="left"] > .tippy-svg-arrow > svg {
+  left: 11px;
+  top: calc(50% - 3px);
+  transform: rotate(90deg);
+}
+
+.tippy-box[data-placement^="right"] > .tippy-svg-arrow {
+  left: 0;
+}
+
+.tippy-box[data-placement^="right"] > .tippy-svg-arrow::after,
+.tippy-box[data-placement^="right"] > .tippy-svg-arrow > svg {
+  right: 11px;
+  top: calc(50% - 3px);
+  transform: rotate(-90deg);
+}
+
+.tippy-svg-arrow {
+  fill: #333;
+  height: 16px;
+  text-align: initial;
+  width: 16px;
+}
+
+.tippy-svg-arrow,
+.tippy-svg-arrow > svg {
+  position: absolute;
 }

--- a/src/css/components/popover.css
+++ b/src/css/components/popover.css
@@ -1,47 +1,11 @@
-.tippy-popper .popover-theme,
-.popover {
+.tippy-box[data-theme~="connector-popover"] {
   background: var(--tertiary);
   border: 1px solid var(--aluminum-3);
   border-radius: 2px;
   box-shadow: 0 2px 9px rgba(0,0,0,.1);
-  padding: var(--xs);
-  transform-origin: 95% 0;
-  transition: opacity var(--transition-speed-sm) var(--transition-timing), transform var(--transition-speed-sm) var(--transition-timing);
-}
-
-/* tippy controlled */
-.tippy-popper:focus {
-  outline: 0;
-}
-
-.version-popover {
-  display: none;
-}
-
-.tippy-popper .version-popover {
-  display: block;
-}
-
-.tippy-popper .popover-theme,
-.tippy-popper .popover,
-.tippy-popper.hide .popover,
-.tippy-popper.hide .popover-theme {
-  opacity: 0;
-  transform: scale(.95) translate3d(2px,-5px,0);
-}
-
-.tippy-popper.shown .popover-theme,
-.tippy-popper.shown .popover {
-  opacity: 1;
-  transform: scale(1) translate3d(0,0,0);
-}
-
-/* popover-level */
-.tippy-popper .popover-theme.popover-level-theme {
-  background: #032d61;
-  color: var(--steel-3);
   font-size: 12px;
-  padding: 0 var(--md);
+  padding-left: 15px;
+  padding-right: 15px;
 }
 
 .tippy-box[data-theme~="current-version-popover"] > .tippy-svg-arrow > svg {
@@ -50,7 +14,7 @@
 
 .tippy-box[data-theme~="current-version-popover"] {
   background: var(--secondary-navy);
-  color: white;
+  color: var(--tertiary);
   font-size: 11px;
   padding: 10px;
 }

--- a/src/css/components/tooltip.css
+++ b/src/css/components/tooltip.css
@@ -5,3 +5,13 @@
   font-size: 11px;
   padding: var(--xs);
 }
+
+.tooltip-dot {
+  background-color: #5e8ef9;
+  border-radius: 50%;
+  display: inline-block;
+  height: 5px;
+  margin-bottom: 2px;
+  margin-right: 3px;
+  width: 5px;
+}

--- a/src/css/components/tooltip.css
+++ b/src/css/components/tooltip.css
@@ -14,4 +14,8 @@
   margin-bottom: 2px;
   margin-right: 3px;
   width: 5px;
+
+  @media screen and (max-width: 768px) {
+    display: none;
+  }
 }

--- a/src/css/globals/global.css
+++ b/src/css/globals/global.css
@@ -35,9 +35,8 @@ body {
   }
 }
 
-.wrapper {
-  max-width: 100vw;
-  width: 100%;
+.hide {
+  display: none;
 }
 
 .main {
@@ -80,6 +79,11 @@ body {
       background-color: #a4a4a4;
     }
   }
+}
+
+.wrapper {
+  max-width: 100vw;
+  width: 100%;
 }
 
 @media (pointer: fine) {

--- a/src/css/specific/nav.css
+++ b/src/css/specific/nav.css
@@ -257,7 +257,7 @@ svg.nav-icon {
   }
 
   & button,
-  & span {
+  & span:not(.tooltip-dot) {
     display: list-item;
     padding: var(--xs) var(--sm);
   }

--- a/src/css/specific/notice-banner.css
+++ b/src/css/specific/notice-banner.css
@@ -43,7 +43,8 @@
     border: none;
     cursor: pointer;
     float: right;
-    font-size: var(--md);
+    font-size: 20px;
+    padding: 11px 17px;
   }
 }
 

--- a/src/css/specific/notice-banner.css
+++ b/src/css/specific/notice-banner.css
@@ -37,6 +37,14 @@
       }
     }
   }
+
+  & .notice-banner-close-button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    float: right;
+    font-size: var(--md);
+  }
 }
 
 .sticky {

--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -322,8 +322,10 @@
   }
 
   function addCurrentVersionIndicator (parentElement) {
-    var currentVersionIndicator = createCurrentVersionIndicator()
-    parentElement.insertBefore(currentVersionIndicator, parentElement.firstChild)
+    if (!isToolTipDot(parentElement.firstChild)) {
+      var currentVersionIndicator = createCurrentVersionIndicator()
+      parentElement.insertBefore(currentVersionIndicator, parentElement.firstChild)
+    }
     return parentElement
   }
 
@@ -352,7 +354,7 @@
   }
 
   function isToolTipDot (element) {
-    return element.classList.contains('tooltip-dot')
+    return element?.classList?.contains('tooltip-dot')
   }
 
   function isSpaceOrEnterKey (keyCode) {
@@ -507,7 +509,8 @@
 
   function selectVersion (navItem, componentData, page, e) {
     toggleNav.call(navItem, componentData, e.target.dataset.version, page)
-    const navVersionButton = document.querySelector('.is-active .nav-version-button')
+    const navVersionButton = document.querySelector(
+      `[data-component="${navItem.getAttribute('data-component')}"] .nav-version-button`)
     if (e.target.dataset.version === getCurrentVersionData(Object.values(componentData.versions)).version) {
       addCurrentVersionIndicator(navVersionButton)
     } else {

--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -323,17 +323,21 @@
 
   function addCurrentVersionIndicator (parentElement) {
     if (!isToolTipDot(parentElement.firstChild)) {
-      var currentVersionIndicator = createCurrentVersionIndicator()
+      console.log(parentElement)
+      var tabIndex = parentElement.classList.contains('nav-version-button') ? 0 : -1
+      var currentVersionIndicator = createCurrentVersionIndicator(tabIndex)
       parentElement.insertBefore(currentVersionIndicator, parentElement.firstChild)
     }
     return parentElement
   }
 
-  function createCurrentVersionIndicator () {
+  function createCurrentVersionIndicator (tabIndex) {
     const currentVersionIndicatorSpan = document.createElement('span')
     currentVersionIndicatorSpan.setAttribute('role', 'tool-tip')
     currentVersionIndicatorSpan.classList.add('tooltip-dot')
+    currentVersionIndicatorSpan.setAttribute('tabindex', tabIndex)
     tippy(currentVersionIndicatorSpan, {
+      a11y: true,
       arrow: tippy.roundArrow,
       content: 'This is the latest version.',
       distance: 100,
@@ -376,6 +380,10 @@
       const navVersionOptions = document.querySelectorAll('.nav-version-option')
       navVersionOptions.forEach(function (navVersionOption) {
         navVersionOption.setAttribute('tabindex', tabIndex)
+      })
+      const tooltipDots = document.querySelectorAll('.nav-version-menu .tooltip-dot')
+      tooltipDots.forEach(function (tooltipDot) {
+        tooltipDot.setAttribute('tabindex', tabIndex)
       })
     }, 200)
   }
@@ -510,7 +518,8 @@
   function selectVersion (navItem, componentData, page, e) {
     toggleNav.call(navItem, componentData, e.target.dataset.version, page)
     const navVersionButton = document.querySelector(
-      `[data-component="${navItem.getAttribute('data-component')}"] .nav-version-button`)
+      `[data-component="${navItem.getAttribute('data-component')}"] .nav-version-button`
+    )
     if (e.target.dataset.version === getCurrentVersionData(Object.values(componentData.versions)).version) {
       addCurrentVersionIndicator(navVersionButton)
     } else {

--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -337,7 +337,6 @@
     currentVersionIndicatorSpan.classList.add('tooltip-dot')
     currentVersionIndicatorSpan.setAttribute('tabindex', tabIndex)
     tippy(currentVersionIndicatorSpan, {
-      a11y: true,
       arrow: tippy.roundArrow,
       content: 'This is the latest version.',
       distance: 100,

--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -323,7 +323,6 @@
 
   function addCurrentVersionIndicator (parentElement) {
     if (!isToolTipDot(parentElement.firstChild)) {
-      console.log(parentElement)
       var tabIndex = parentElement.classList.contains('nav-version-button') ? 0 : -1
       var currentVersionIndicator = createCurrentVersionIndicator(tabIndex)
       parentElement.insertBefore(currentVersionIndicator, parentElement.firstChild)

--- a/src/js/07-connectors.js
+++ b/src/js/07-connectors.js
@@ -36,29 +36,15 @@
 
     if (msg) {
       tippy(connectorTierTrigger, {
-        boundary: 'window',
+        allowHTML: true,
         content: msg,
-        duration: [0, 150],
-        flip: false,
+        // duration: [0, 150],
         maxWidth: 240,
-        offset: '0, 10',
+        offset: [0, 10],
         placement: 'bottom-end',
-        role: 'menu',
-        theme: 'popover popover-level',
+        theme: 'connector-popover',
         touchHold: true, // maps touch as click (for some reason)
         zIndex: 14, // same as z-nav-mobile
-        onHide: function (instance) {
-          instance.popper.classList.remove('shown')
-        },
-        onHidden: function (instance) {
-          instance.popper.classList.add('hide')
-        },
-        onShow: function (instance) {
-          instance.popper.classList.remove('hide')
-        },
-        onShown: function (instance) {
-          instance.popper.classList.add('shown')
-        },
       })
     }
   }

--- a/src/js/10-notice-banner.js
+++ b/src/js/10-notice-banner.js
@@ -10,9 +10,9 @@
     }
   }
 
-  var noticeBannerCloseButton = document.querySelector('.notice-banner-close')
+  var noticeBannerCloseButton = document.querySelector('.notice-banner-close-button')
   if (noticeBannerCloseButton) {
-    noticeBannerCloseButton.addEventListener('click', function (e) {
+    noticeBannerCloseButton.addEventListener('click', function (_e) {
       if (noticeBannerContainer) {
         noticeBannerContainer.classList.add('hide')
       }

--- a/src/js/10-notice-banner.js
+++ b/src/js/10-notice-banner.js
@@ -1,13 +1,30 @@
 ;(function () {
   'use strict'
 
-  var depContainer = document.getElementsByClassName('notice-banner')[0]
-  if (depContainer) {
-    var toolBar = document.getElementsByClassName('toolbar')[0]
-    var sticky = depContainer.offsetTop
+  var noticeBannerContainer = document.querySelector('.notice-banner')
+  if (noticeBannerContainer) {
+    var toolbar = document.querySelector('.toolbar')
+    var sticky = noticeBannerContainer.offsetTop
     window.onscroll = function () {
-      makeSticky(depContainer, toolBar, sticky)
+      makeSticky(noticeBannerContainer, toolbar, sticky)
     }
+  }
+
+  var noticeBannerCloseButton = document.querySelector('.notice-banner-close')
+  if (noticeBannerCloseButton) {
+    noticeBannerCloseButton.addEventListener('click', function (e) {
+      if (noticeBannerContainer) {
+        noticeBannerContainer.classList.add('hide')
+      }
+    })
+    noticeBannerCloseButton.addEventListener('keydown', function (e) {
+      if (isSpaceOrEnterKey(e.keyCode)) {
+        if (noticeBannerContainer) {
+          noticeBannerContainer.classList.add('hide')
+          e.preventDefault()
+        }
+      }
+    })
   }
 
   function makeSticky (dc, t, s) {
@@ -16,5 +33,9 @@
     } else {
       dc.classList.remove('sticky')
     }
+  }
+
+  function isSpaceOrEnterKey (keyCode) {
+    return [13, 32].includes(keyCode)
   }
 })()

--- a/src/partials/notice-banner.hbs
+++ b/src/partials/notice-banner.hbs
@@ -9,6 +9,7 @@
       page.componentVersion.asciidoc.attributes.olderVersion))
     }}
     <div class="notice-banner">
+      <button class="notice-banner-close-button" title="Close the notice banner">&times;</button>
       {{#if page.componentVersion.asciidoc.attributes.endOfLife}}
       <p>This version of the product has reached 
         <a class="notice-banner-link" 


### PR DESCRIPTION
ref: W-10592536

- add a blue dot indicator for the current version in the left nav version selector. The indicator has a tooltip that tells users what it means
- upgrade a library called tippy.js to the latest version
- add close button ("x") to deprecated notice banners to allow users to close it temporarily. It will display again when page is refreshed, no cookie is involved

current version indcator:
https://www.loom.com/share/5a84587a82384ae79d23a282f70fb259

notice banner close button:
https://www.loom.com/share/34e6a6a7a1934f5f86aaad183a6279f1