### PR TITLE
[W-12029864] make hovering area bigger

### DIFF
--- a/src/css/components/tooltip.css
+++ b/src/css/components/tooltip.css
@@ -28,11 +28,11 @@
   height: 5px;
   width: 5px;
 
-  &:after{
-    padding: 8px;
+  &::after {
     content: '';
+    padding: 8px;
     position: absolute;
-    transform: translate(-50%, -50%);
+    transform: translate(-50%,-50%);
   }
 
   &.tooltip-dot-nav-version-menu {

--- a/src/css/components/tooltip.css
+++ b/src/css/components/tooltip.css
@@ -28,6 +28,13 @@
   height: 5px;
   width: 5px;
 
+  &:after{
+    padding: 8px;
+    content: '';
+    position: absolute;
+    transform: translate(-50%, -50%);
+  }
+
   &.tooltip-dot-nav-version-menu {
     margin-bottom: 1px;
     margin-right: 3px;


### PR DESCRIPTION
ref: [W-12029864](https://gus.lightning.force.com/a07EE00001BucOkYAJ)

the CSS change will allow the tooltip to show when hovering in the surrounding areas of the tooltip. This makes it easier to use the tooltip (in the screenshot below, the red circle indicates the rough hovering area)

![Screenshot 2022-11-14 at 10 38 15 AM](https://user-images.githubusercontent.com/10934908/201739714-1de37b7a-b1df-4633-8df7-3b8dda2109d7.png)
