### PR TITLE
W-11996638 force version border gc

### DIFF
--- a/src/css/components/tooltip.css
+++ b/src/css/components/tooltip.css
@@ -26,6 +26,7 @@
   border-radius: 50%;
   float: left;
   height: 5px;
+  outline-style: none;
   width: 5px;
 
   &::after {
@@ -44,8 +45,4 @@
     margin-left: 6px;
     margin-top: 8px;
   }
-
-  /* @media screen and (max-width: 768px) {
-    display: none;
-  } */
 }

--- a/src/css/specific/nav.css
+++ b/src/css/specific/nav.css
@@ -218,6 +218,10 @@ svg.nav-icon {
   border-radius: 10px;
   margin: -3px -14px;
   padding: 3px 14px;
+
+  &:focus {
+    border: 1px solid var(--secondary-navy);
+  }
 }
 
 .nav-version-dropdown {


### PR DESCRIPTION
ref: [W-11996638](https://gus.lightning.force.com/lightning/r/a07EE00001BKHzKYAX/view)

- fix a bug where on some web browsers (for example safari), when focusing on version selector buttons, the border does not show
