### PR TITLE
[W-10813743] update footer colors

### DIFF
--- a/src/css/specific/header.css
+++ b/src/css/specific/header.css
@@ -24,7 +24,7 @@
 
 .ms-com-content.ms-com-content.ms-com-content-header header.ms-com-header .header-wrapper .header-inside,
 .ms-com-content.ms-com-content.ms-com-content-footer footer .footer-inside,
-.ms-com-content.ms-com-content.ms-com-content-footer footer .footer-bottom .footer-inside {
+.ms-com-content.ms-com-content.ms-com-content-footer footer .footer-bottom .footer-inside, {
   max-width: var(--screen-xl);
 
   @media (--xxl) {
@@ -43,4 +43,36 @@
     height: 100%;
     padding-top: 65px;
   }
+}
+
+.ms-com-content.ms-com-content-footer footer .footer-top a {
+  color: var(--secondary-navy) !important;
+
+  &:active,
+  &:focus {
+    border-radius: 5px;
+    outline: 2px solid #888;
+    text-decoration: none;
+  }
+
+  &:hover {
+    background-color: #c0edff;
+    border-radius: 5px;
+    color: var(--secondary-navy);
+    margin-left: -3px;
+    margin-right: -3px;
+    padding: 1px 3px;
+
+    &:not(.mulecopy a) {
+     margin-right: 7px;
+    }
+  }
+
+  &:visited {
+    color: #681da8;
+  }
+}
+
+.footer-copyright {
+  color: #757575 !important;
 }

--- a/src/css/specific/header.css
+++ b/src/css/specific/header.css
@@ -64,7 +64,7 @@
     padding: 1px 3px;
 
     &:not(.mulecopy a) {
-     margin-right: 7px;
+      margin-right: 7px;
     }
   }
 

--- a/src/partials/footer-content.hbs
+++ b/src/partials/footer-content.hbs
@@ -53,9 +53,7 @@
                         href="https://www.mulesoft.com/content/terms-service" target="_blank">Terms</a> <a
                         href="https://www.mulesoft.com/privacy-policy" target="_blank">Privacy</a> <a
                         href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Privacy/privacy-shield-notice.pdf"
-                        target="_blank">Privacy Shield</a> <button
-                        class="ot-sdk-show-settings optanon-toggle-display removable" data-ignore-geolocation="true"
-                        id="ot-sdk-btn">Cookie settings</button> <a class="removable"
+                        target="_blank">Privacy Shield</a> <a class="removable"
                         href="https://www.mulesoft.com/contact" target="_blank">Contact</a> <a class="removable"
                         href="https://www.mulesoft.com/contact" target="_blank"> 1-415-229-2009</a> </nav>
                 <p class="mulecopy">MuleSoft provides a widely used <a


### PR DESCRIPTION
ref: [W-10813743](https://gus.lightning.force.com/lightning/r/a07EE00000sL8LwYAK/view)

- update footer link colors to be more accessible
- remove a button called "Cookie Settings". It currently doesn't do anything so I took it out, but it should be back when we upgrade to the new footer.

<img width="917" alt="Screenshot 2022-12-13 at 8 30 14 AM" src="https://user-images.githubusercontent.com/10934908/207389826-72083545-adff-4fc8-9125-bf0d3810c737.png">

