### PR TITLE
[W-12207708] thicker skip link focus borders

### DIFF
--- a/src/css/components/skiplink.css
+++ b/src/css/components/skiplink.css
@@ -34,6 +34,6 @@
 
   &:focus {
     color: var(--secondary-navy);
-    outline: 2px solid #888;
+    outline: 3px solid #888;
   }
 }

--- a/src/js/15-skiplink-listeners.js
+++ b/src/js/15-skiplink-listeners.js
@@ -58,14 +58,6 @@
     }
   }
 
-  const getFocusableSearchBox = () => {
-    const atomicSearchbox = document.querySelector('atomic-search-box')
-    const searchboxShadowRoot = atomicSearchbox && atomicSearchbox.shadowRoot
-    if (searchboxShadowRoot) {
-      return searchboxShadowRoot.querySelector('input')
-    }
-  }
-
   const getSkipLinks = () => {
     return document.querySelectorAll('.skip-link')
   }

--- a/src/js/15-skiplink-listeners.js
+++ b/src/js/15-skiplink-listeners.js
@@ -2,21 +2,25 @@
   'use strict'
 
   const addEventListenersToSkipLinks = () => {
-    const skipLinks = document.querySelectorAll('.skip-link')
+    let skipLinks = getSkipLinks()
     const [leftNavSkipLink, mainContentSkipLink, pageNavSkipLink] = skipLinks
 
-    clickToRemoveFocus(leftNavSkipLink)
-    clickToRemoveFocus(mainContentSkipLink)
-    clickToRemoveFocus(pageNavSkipLink)
+    if (hasNav()) {
+      leftNavSkipLink.addEventListener('keydown', (e) => {
+        focusOn(e, '#search-button')
+      })
+    } else {
+      removeElement(leftNavSkipLink)
+    }
 
-    leftNavSkipLink.addEventListener('keydown', (e) => {
-      focusOn(e, '#search-button')
-    })
-
-    mainContentSkipLink.addEventListener('keydown', (e) => {
-      const selectors = toolbarIsVisible() ? '.toolbar a:not(.home-link)' : '.doc a'
-      focusOn(e, selectors)
-    })
+    if (hasMain()) {
+      mainContentSkipLink.addEventListener('keydown', (e) => {
+        const selectors = toolbarIsVisible() ? '.toolbar a:not(.home-link)' : '.doc a'
+        focusOn(e, selectors)
+      })
+    } else {
+      removeElement(mainContentSkipLink)
+    }
 
     if (hasAside()) {
       pageNavSkipLink.addEventListener('keydown', (e) => {
@@ -25,10 +29,17 @@
     } else {
       removeElement(pageNavSkipLink)
     }
+
+    skipLinks = getSkipLinks()
+    if (skipLinks.length > 0) {
+      clickToRemoveFocus(skipLinks)
+    } else {
+      removeElement(skipLinks)
+    }
   }
 
-  const clickToRemoveFocus = (element) => {
-    if (element) {
+  const clickToRemoveFocus = (elements) => {
+    for (const element of elements) {
       element.addEventListener('click', (e) => {
         element.blur()
         e.preventDefault()
@@ -38,13 +49,37 @@
 
   const focusOn = (e, selectors) => {
     if (isSpaceOrEnterKey(e.keyCode)) {
-      document.querySelector(selectors).focus()
+      if (typeof selectors === 'string') {
+        document.querySelector(selectors).focus()
+      } else {
+        selectors.focus()
+      }
       e.preventDefault()
     }
   }
 
+  const getFocusableSearchBox = () => {
+    const atomicSearchbox = document.querySelector('atomic-search-box')
+    const searchboxShadowRoot = atomicSearchbox && atomicSearchbox.shadowRoot
+    if (searchboxShadowRoot) {
+      return searchboxShadowRoot.querySelector('input')
+    }
+  }
+
+  const getSkipLinks = () => {
+    return document.querySelectorAll('.skip-link')
+  }
+
   const hasAside = () => {
     return document.querySelector('.js-toc')
+  }
+
+  const hasMain = () => {
+    return document.querySelector('main')
+  }
+
+  const hasNav = () => {
+    return document.querySelector('nav.nav')
   }
 
   const isSpaceOrEnterKey = (keyCode) => {


### PR DESCRIPTION
ref: [W-12207708](https://gus.lightning.force.com/a07EE00001HIUuQYAX)

- make skip link focus state borders thicker:

  <img width="467" alt="Screenshot 2022-12-13 at 10 27 19 AM" src="https://user-images.githubusercontent.com/10934908/207416011-e4677f2d-58bf-46f6-8577-31ba4063ece8.png">

- handle errors better for skip links:
  - if a target section (left nav, main, or right nav) isn't present, the corresponding skip link is removed
  - if there are no skip links, the entire skiplink div section is removed
