### PR TITLE
[W-12221399] better error handling

### DIFF
--- a/src/helpers/release-notes.js
+++ b/src/helpers/release-notes.js
@@ -46,7 +46,9 @@ const getResultList = (pageUIModels, maxNumberOfPages) => {
   for (let i = 0; i < maxNumberOfPages; i++) {
     const page = pageUIModels[i]
     if (page.attributes?.revdate) {
-      resultList.push(getSelectedAttributes(page))
+      if (page.title) {
+        resultList.push(getSelectedAttributes(page))
+      }
     }
   }
   return resultList
@@ -98,8 +100,10 @@ const removeYear = (dateStr) => {
 }
 
 const cleanTitle = (title) => {
-  const splitList = title.split('Release Notes')
-  return splitList[0].trim()
+  if (title) {
+    const splitList = title.split('Release Notes')
+    return splitList[0].trim()
+  }
 }
 
 module.exports = (numOfItems, { data }) => {


### PR DESCRIPTION
ref: [W-12221399](https://gus.lightning.force.com/a07EE00001HUHIwYAP)

handle error where the release notes helper function breaks the build if the release notes includes a partial from a repo that is not part of a playbook. For example, docs-release-notes has a partial from docs-rpa, but a beta site playbook includes docs-release-notes but not docs-rpa.

In the above scenario, the docs-rpa partial would simply be skipped, resulting in the following screenshot where there is supposed to be 5 releases listed in the "latest release" section, but it shows 4 instead since 1 of them has been skipped.

![Screenshot 2022-12-14 at 12 28 20 PM](https://user-images.githubusercontent.com/10934908/207707121-367db76c-1b22-4c55-9520-507718a2b9d1.png)
