### PR TITLE
[W-12207708] add !important tag to skip link

### DIFF
--- a/src/css/components/skiplink.css
+++ b/src/css/components/skiplink.css
@@ -35,7 +35,7 @@
   &:active,
   &:focus {
     color: var(--secondary-navy);
-    outline: 3px solid #888;
+    outline: 3px solid #888 !important;
   }
 
   &:hover {


### PR DESCRIPTION
ref: [W-12207708](https://gus.lightning.force.com/a07EE00001HIUuQYAX)

mark the skip link outline CSS as `!important` to override the default, so the border can show properly.