### PR TITLE
[W-12466223] onboard composer to "latest release notes" section + fix initial scroll position

### DIFF
--- a/preview-site-src/index.adoc
+++ b/preview-site-src/index.adoc
@@ -10,7 +10,7 @@ xref:api-led-overview.adoc[New to MuleSoft? Start here.]
 [#the-road]
 == The Road to Digital Transformation
 
-image::getting-started.png[Getting Started]
+image::getting-started.png[alt=""]
 
 --
 [discrete]
@@ -21,7 +21,7 @@ Build the digital transformation your business needs.
 * xref:api-led-overview.adoc[Tutorial: Build an API from start to finish.]
 --
 
-image::discover.png[Discover]
+image::discover.png[alt=""]
 
 --
 [discrete]
@@ -32,7 +32,7 @@ Browse Exchange to find existing API specifications, templates, examples, and ot
 * https://www.anypoint.mulesoft.com/exchange/[Discover reusable assets.^]
 --
 
-image::design.png[Design]
+image::design.png[alt=""]
 
 --
 [discrete]
@@ -45,7 +45,7 @@ Create and publish new API specifications from scratch.
 * xref:general::security.adoc[Build security into your application network.]
 --
 
-image::develop.png[Develop and Test]
+image::develop.png[alt=""]
 
 --
 [discrete]
@@ -60,20 +60,20 @@ Build and test APIs and integration apps.
 * xref:munit::index.adoc[Build automated tests for your APIs and integrations.]
 --
 
-image::deploy.png[Deploy]
+image::deploy.png[alt=""]
 
 --
 [discrete]
 === Deploy
 
-Deploy APIs and apps to your hosting targets, and secure them with policies.
+Choose a deployment option, deploy APIs and apps, and secure them with policies.
 
 * xref:runtime-manager::deployment-strategies.adoc[Choose a deployment option.]
 * xref:api-manager::api-proxy-landing-page.adoc[Configure a proxy for your API.]
-* xref:gateway::policies-overview.adoc[Create policies to secure your API.]
+* xref:policies::policies-policy-overview.adoc[Create policies to secure your API.]
 --
 
-image::monitor.png[Monitor]
+image::monitor.png[alt=""]
 
 --
 [discrete]
@@ -87,30 +87,6 @@ Monitor your APIs and integrations using dashboards, metrics, and visualization.
 --
 
 == Quick Links
-
-[#latest-releases]
-=== Latest Releases
-
-// removing table until we can automate, keeping hidden here for future reference
-[cols=10;90]
-|===
-|April 11
-|xref:api-functional-monitoring/api-functional-monitoring-release-notes.adoc[API Functional Monitoring 2.1]
-
-|April 11
-|xref:connector/connector-db.adoc#1-13-0[Database Connector 1.13]
-
-|April 2
-|xref:design-center/design-center-release-notes-api_specs.adoc#2-41-0[API Designer (Crowd) Release Notes 2.41]
-
-|April 2
-|xref:api-mocking-service/api-mocking-service-release-notes.adoc#2-38-0[API Mocking Service Release Notes 2.38]
-
-|March 31
-|xref:studio/anypoint-studio-7.12-with-4.4-runtime-release-notes.adoc[Anypoint Studio 7.12]
-|===
-
-xref:#[View all release notes,role=view-all]
 
 [#popular-topics]
 === Popular Topics

--- a/src/helpers/release-notes.js
+++ b/src/helpers/release-notes.js
@@ -1,4 +1,5 @@
 const maxNumofItems = 10
+const components = ['composer', 'release-notes']
 
 const getDatedReleaseNotesRawPages = (contentCatalog) => {
   return contentCatalog.getPages(({ asciidoc, out }) => {
@@ -13,7 +14,7 @@ const getReleaseNotesWithRevdate = (asciidoc) => {
 }
 
 const isReleaseNotes = (attributes) => {
-  return attributes['page-component-name'] === 'release-notes'
+  return components.includes(attributes['page-component-name'])
 }
 
 const hasRevDate = (attributes) => {

--- a/src/js/02-table-of-content.js
+++ b/src/js/02-table-of-content.js
@@ -5,6 +5,12 @@
     return toArray((from || document).querySelectorAll(selector))
   }
 
+  const fixInitialScrollPosition = () => {
+    window.addEventListener('load', () => {
+      if (window.location.hash.length) window.scrollBy(0, -50)
+    })
+  }
+
   const isSpaceKey = (e) => {
     return e.charCode === 32
   }
@@ -83,6 +89,7 @@
       this.dropdownArrow.src = `${uiRootPath}/img/icons/dropdown-arrow.svg`
       this.dropdownArrow.alt = ''
       this.dropdownArrow.ariaLabel = 'Expand page contents'
+      this.dropdownArrow.role = 'button'
       this.selectWrap.appendChild(this.dropdownArrow)
     }
 
@@ -104,7 +111,7 @@
       this.createTocMenuDiv()
       if (this.sidebar) {
         window.addEventListener('scroll', (_e) => {
-          this.onScroll()
+          this.highlightOnScroll()
         })
       }
 
@@ -130,7 +137,7 @@
       }
     }
 
-    onScroll () {
+    highlightOnScroll () {
       // NOTE equivalent to: doc.parentNode.getBoundingClientRect().top + window.pageYOffset
       const targetPosition = this.doc.parentNode.offsetTop
       let activeFragment
@@ -196,4 +203,6 @@
       viewport.createToc()
     }
   }
+
+  fixInitialScrollPosition()
 })()

--- a/src/js/02-table-of-content.js
+++ b/src/js/02-table-of-content.js
@@ -7,8 +7,15 @@
 
   const fixInitialScrollPosition = () => {
     window.addEventListener('load', () => {
-      if (window.location.hash.length) window.scrollBy(0, -50)
+      if (window.location.hash.length) {
+        const scrollValue = isBigScreenSize ? -50 : -100
+        window.scrollBy(0, scrollValue)
+      }
     })
+  }
+
+  const isBigScreenSize = () => {
+    return window.innerWidth >= 768
   }
 
   const isSpaceKey = (e) => {


### PR DESCRIPTION
ref: W-12466223

- add composer to be included in the "latest release notes" section
- fix page position by scrolling down for URLs that have an anchor. For example, open https://docs.mulesoft.com/release-notes/connector/amazon-s3-connector-release-notes-mule-4#6-1-0 would show the top of the section blocked by the marketing header
- add button role to the dropdown arrow introduced in #295 
- update preview site's index page