### PR TITLE
[W-12505704] add extended support banner

### DIFF
--- a/src/partials/notice-banner/message-for-extended-support-banner.hbs
+++ b/src/partials/notice-banner/message-for-extended-support-banner.hbs
@@ -1,0 +1,8 @@
+{{#if page.latest.url}}
+This version of the product
+{{else}}
+This product
+{{/if}}
+has entered
+<a class="notice-banner-link" href="https://www.mulesoft.com/legal/versioning-back-support-policy" target="_blank"
+    rel="noopener noreferrer">Extended Support</a>.

--- a/src/partials/notice-banner/notice-banner.hbs
+++ b/src/partials/notice-banner/notice-banner.hbs
@@ -4,9 +4,13 @@
   <p>{{page.attributes.notice-banner-message}}</p>
 </div>
 {{else}}
-{{#if (or page.componentVersion.asciidoc.attributes.endOfLife (or
+{{#if (or
+page.componentVersion.asciidoc.attributes.endOfLife (or
 page.componentVersion.asciidoc.attributes.endOfLifeScheduled (or
-page.componentVersion.asciidoc.attributes.noLongerUpdated page.componentVersion.asciidoc.attributes.olderVersion)))}}
+page.componentVersion.asciidoc.attributes.extendedSupport (or
+page.componentVersion.asciidoc.attributes.noLongerUpdated page.componentVersion.asciidoc.attributes.olderVersion
+))))
+}}
 <div class="notice-banner">
   <button class="notice-banner-close-button" title="Close notice banner">&times;</button>
   <p>
@@ -16,7 +20,11 @@ page.componentVersion.asciidoc.attributes.noLongerUpdated page.componentVersion.
     {{#if page.componentVersion.asciidoc.attributes.endOfLifeScheduled}}
     {{> message-for-eol-scheduled-banner}}
     {{else}}
+    {{#if page.componentVersion.asciidoc.attributes.extendedSupport}}
+    {{> message-for-extended-support-banner}}
+    {{else}}
     {{> message-for-old-banner}}
+    {{/if}}
     {{/if}}
     {{/if}}
     {{#if page.latest.url}}


### PR DESCRIPTION
ref: W-12505704

Add extended support version banner.

![Screenshot 2023-02-07 at 4 16 11 PM](https://user-images.githubusercontent.com/10934908/217396627-c5b86967-8aab-423a-aa31-72e4614ed613.png)

This is done by having the following in a doc repo's antora.yml:

```yml
asciidoc:
  attributes:
    extendedSupport: true
```