### PR TITLE
[W-12500977] remove duplicate breadcrumbs from index pages

### DIFF
--- a/src/partials/breadcrumbs.hbs
+++ b/src/partials/breadcrumbs.hbs
@@ -15,14 +15,13 @@
     </a>
   </li>
   {{#with page.componentVersion}}
-  {{#if (and ./title (and (ne ./title 'Home') (ne ./title 'ホーム') (not (or ./root (eq @root.page.breadcrumbs.0.content
-  ./title)))))}}
+  {{#if (and (and ./title (and (ne ./title 'Home') (ne ./title 'ホーム') (not (or ./root (eq
+  @root.page.breadcrumbs.0.content ./title))))) (ne @root.page.url ./url))}}
   <li class="flex align-center li"><a class="link" href="{{{relativize ./url}}}">{{{./title}}}</a></li>
   {{/if}}
   {{/with}}
   {{#each page.breadcrumbs}}
-  {{#if (eq ./urlType 'internal')}}
-  {{#if (ne @root.page.url ./url)}}
+  {{#if (and (eq ./urlType 'internal') (ne @root.page.url ./url))}}
   {{#if (ne @root.page.breadcrumbs.0.url ./url)}}
   <li class="flex align-center li"><a class="link" href="{{{relativize ./url}}}">{{{./content}}}</a></li>
   {{/if}}
@@ -30,7 +29,6 @@
   <li class="flex align-center li">
     <p>{{{./content}}}</p>
   </li>
-  {{/if}}
   {{/if}}
   {{/each}}
 </ol>


### PR DESCRIPTION
ref: W-12500977

Fix a bug where for each component's index pages, there still exists a duplicate entry in the breadcrumbs:
![Screenshot 2023-02-10 at 11 41 36 AM](https://user-images.githubusercontent.com/10934908/218183228-8ac85061-5fd1-4435-91fe-4c85a2b990ca.png)

The solution is to add an additional condition check to exclude index pages. Below is the result:
![Screenshot 2023-02-10 at 11 42 42 AM](https://user-images.githubusercontent.com/10934908/218183372-3e9182f3-b48c-47a2-a227-076d927e46b3.png)

