### PR TITLE
[W-10592816] update metadata

### DIFF
--- a/gulp.d/tasks/release.js
+++ b/gulp.d/tasks/release.js
@@ -272,12 +272,12 @@ module.exports = (dest, bundleName, owner, repo, token, updateBranch) => async (
   const gitHub = new GitHub({ dest, bundleName, owner, repo, token, updateBranch })
   await gitHub.setUp()
   await gitHub.createNextRelease()
-  if (gitHub.variant === 'prod') {
-    await gitHub.createPR({
-      repo: 'docs-site-playbook',
-      ref: 'master',
-      filePath: 'antora-playbook.yml',
-    })
-    // TODO: add more createPR for other branches, like archive, jp, maybe even (need refactoring) beta and internal
-  }
+  // if (gitHub.variant === 'prod') {
+  //   await gitHub.createPR({
+  //     repo: 'docs-site-playbook',
+  //     ref: 'master',
+  //     filePath: 'antora-playbook.yml',
+  //   })
+  //   // TODO: add more createPR for other branches, like archive, jp, maybe even (need refactoring) beta and internal
+  // }
 }

--- a/src/partials/head/head-meta.hbs
+++ b/src/partials/head/head-meta.hbs
@@ -1,10 +1,12 @@
 {{#if page.component}}
+<meta name="mulesoftproduct" content="{{page.component.title}}">
 <meta name="product" content="{{page.component.title}}">
 {{#if (eq page.component.latest.version page.version)}}
-<meta name="is-latest-version" content="true">
+<meta name="mulesoftislatestversion" content="true">
 {{/if}}
-<meta name="mulesoft-product-version" content="{{page.component.title}}|{{or page.displayVersion page.version}}">
-<meta name="latest-version" content="{{page.component.latest.version}}">
+<meta name="mulesoftproductversion" content="{{page.component.title}}|{{or page.displayVersion page.version}}">
+<meta name="mulesoftlatestversion" content="{{page.component.latest.version}}">
+<meta name="mulesoftversion" content="{{or page.displayVersion page.version}}">
 <meta name="version" content="{{or page.displayVersion page.version}}">
 <meta name="page-url" content="{{page.url}}">
 <meta name="page-component" content="{{page.component.name}}">


### PR DESCRIPTION
ref: W-10592816

Update metadata:
 - rename them to `mulesoft*` so they are separate than the `sf*` ones (the old metadata are kept for backwards compatibility)
 - remove hyphens to be compatible with Coveo searches

Temporarily remove the capability to auto-create PR since the git commits created this way are unverified. See [W-10876368](https://gus.lightning.force.com/a07EE00000tMS2ZYAW) for further detail.