### PR TITLE
[W-12550440] revert metadata

### DIFF
--- a/src/partials/head/head-meta.hbs
+++ b/src/partials/head/head-meta.hbs
@@ -1,13 +1,12 @@
 {{#if page.component}}
-<meta name="mulesoftproduct" content="{{page.component.title}}">
 <meta name="product" content="{{page.component.title}}">
+{{#if page.latest.url}}
 {{#if (eq page.component.latest.version page.version)}}
-<meta name="mulesoftislatestversion" content="true">
+<meta name="is-latest-version" content="true">
 {{/if}}
-<meta name="mulesoftproductversion" content="{{page.component.title}}|{{or page.displayVersion page.version}}">
-<meta name="mulesoftlatestversion" content="{{page.component.latest.version}}">
-<meta name="mulesoftversion" content="{{or page.displayVersion page.version}}">
+<meta name="latest-version" content="{{page.component.latest.version}}">
 <meta name="version" content="{{or page.displayVersion page.version}}">
+{{/if}}
 <meta name="page-url" content="{{page.url}}">
 <meta name="page-component" content="{{page.component.name}}">
 <meta name="page-version" content="{{page.version}}">


### PR DESCRIPTION
ref: W-12550440

This PR is an extension for the work #298, #304, #307, and #310. It's actually reverting many of the changes there, since I have learned how Coveo maps the metadata (need to document this later).

Here are the new set of metadata:

| Metadata Name         | Description     | Condition to appear |
|--------------|-----------|------------|
| product | name of the component     | always appear |
| is-latest-version      | if the page belongs to the latest version of a component  | only if the component has multiple versions. So it does not show up for `master` or `default` |
| latest-version | (if available) the latest version of the component | only if the component has multiple versions. So it does not show up for `master` or `default` |
| version | the version of the component | only if the component has multiple versions. So it does not show up for `master` or `default` |