### PR TITLE
[W-12594329] adjust modal z-index

### DIFF
--- a/src/css/globals/vars.css
+++ b/src/css/globals/vars.css
@@ -75,7 +75,7 @@
   --z-nav-mobile: 18;
   --z-modal-header: 17;
   --z-backdrop: 16;
-  --z-modal: 16;
+  --z-modal: 110;
   --z-header: 11;
   --z-banner: 10;
   --z-nav: 9;


### PR DESCRIPTION
ref: [W-12594329](https://gus.lightning.force.com/a07EE00001LnLr7YAF)

make modal z-index higher so that marketing header doesn't block it anymore.