### PR TITLE
[W-12550440] add version-with-latest metadata for all versions

### DIFF
--- a/src/partials/head/head-meta.hbs
+++ b/src/partials/head/head-meta.hbs
@@ -2,9 +2,9 @@
 <meta name="product" content="{{page.component.title}}">
 {{#if page.latest.url}} 
 <meta name="version" content="{{or page.displayVersion page.version}}">
+<meta name="version-with-latest" content="{{or page.displayVersion page.version}} [latest]">
 {{#if (eq page.component.latest.version page.version)}}
 <meta name="is-latest-version" content="true">
-<meta name="version-with-latest" content="{{or page.displayVersion page.version}} [latest]">
 {{else}}
 <meta name="latest-version" content="{{page.component.latest.version}}">
 {{/if}}


### PR DESCRIPTION
ref: W-12550440

`version-with-latest` will be used as a searchable field for ALL versions in the new search UI. Prior to this PR, this field was only available for the latest versions