### PR TITLE
[W-12648204] left nav height adjust + status banners

### DIFF
--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -127,8 +127,20 @@
       : versions[0]
   }
 
+  const getWindowsHeightMinus = (element) => {
+    const rect = element.getBoundingClientRect()
+    const viewHeight = Math.max(document.documentElement.clientHeight, window.innerHeight)
+    return viewHeight - rect.y
+  }
+
   const isBigScreenSize = () => {
     return window.innerWidth >= 768
+  }
+
+  const isVisible = (element) => {
+    const rect = element.getBoundingClientRect()
+    const viewHeight = Math.max(document.documentElement.clientHeight, window.innerHeight)
+    return !(rect.bottom < 0 || rect.top - viewHeight >= 0)
   }
 
   const selectComponents = (patterns, pool, exclude) => {
@@ -360,12 +372,17 @@
 
     adjustNavHeight (e) {
       if (this.nav) {
-        const header = document.querySelector('.ms-com-content')
-        if (header) {
+        const header = document.querySelector('.ms-com-content-header')
+        const footer = document.querySelector('.ms-com-content-footer')
+        if (header && footer) {
           if (isBigScreenSize()) {
             const bannerHeight = getBannerHeight()
             if (window.pageYOffset + bannerHeight > header.offsetHeight) {
-              this.nav.style.height = '100vh'
+              let heightValue = isVisible(footer) ? `calc(100vh - ${getWindowsHeightMinus(footer)}px` : 'calc(100vh'
+              if (hasTopBanner()) {
+                heightValue += ' - var(--banner-height)'
+              }
+              this.nav.style.height = `${heightValue})`
             } else {
               this.nav.style.height = hasTopBanner()
                 ? 'calc(100vh - var(--header-height) - var(--banner-height))'

--- a/src/partials/notice-banner/banner-latest-version-snippet.hbs
+++ b/src/partials/notice-banner/banner-latest-version-snippet.hbs
@@ -1,4 +1,4 @@
-{{#if page.latest.url}}
+{{#if (and page.latest.url (ne page.componentVersion.asciidoc.attributes.latestVersionSwitch false))}}
 You can switch to the
 <a class="notice-banner-link" href="{{site.url}}{{page.latest.url}}">latest version</a>,
 or use the version selector in the left navigation.

--- a/src/partials/notice-banner/eol-reached/banner-for-eol-reached.hbs
+++ b/src/partials/notice-banner/eol-reached/banner-for-eol-reached.hbs
@@ -3,6 +3,6 @@
     <p>
         This product has reached
         <a class="notice-banner-link" href="https://www.mulesoft.com/legal/versioning-back-support-policy"
-            target="_blank" rel="noopener noreferrer">End of Life</a> and is no longer supported.
+            target="_blank" rel="noopener noreferrer">End of Life</a>.
     </p>
 </div>


### PR DESCRIPTION
ref: W-12648204

### left nav height

add extra logic to the nav javascript so that when a user scrolls to the bottom of the page, the user is able to scroll the left nav all the way to the top

![Screenshot 2023-03-07 at 11 34 13 AM](https://user-images.githubusercontent.com/10934908/223533664-03f7346b-b0cf-4a68-9555-eee2ea622997.png)

### status banners

add an extra attribute `latestVersionSwitch` to suppress the "switch to the latest version" clause. This satisfies a use case where for certain old versions where migration is too complex to the latest version, we want to omit the clause.

Usage:
```yml
name: runtime-fabric
title: Runtime Fabric
version: '1.8'
nav:
- modules/ROOT/nav.adoc
asciidoc:
  attributes:
    supportStatus: eolSupportVersion
    latestVersionSwitch: false
    # by default, omitting latestVersionSwitch 
    # or having a different value of latestVersionSwitch (for example: latestVersionSwitch: true)
    # will allow the clause to show
```

Also remove `and is no longer supported.` at the end of the `eolReached` status banner.