### PR TITLE
[W-12660819] add latest version release

### DIFF
--- a/gulp.d/tasks/release.js
+++ b/gulp.d/tasks/release.js
@@ -21,16 +21,13 @@ class GitHub {
   async setUp () {
     this.branchName = await this.setBranchName()
     this.variant = this.branchName === 'master' ? 'prod' : this.branchName
-    this.prefix = `${this.variant}-`
     this.ref = `heads/${this.branchName}`
 
-    this.currentReleaseNumber = await this.getCurrentReleaseNumber()
-    this.nextReleaseNumber = this.currentReleaseNumber + 1
-
-    this.tagName = `${this.variant}-${this.nextReleaseNumber}`
+    this.tagName = `${this.variant}-${await this.getCurrentReleaseNumber() + 1}`
     this.releaseMessage = `Release ${this.tagName}`
 
-    this.latestPRLink = await this.getLatestPRLink()
+    this.lastPRLink = await this.getLastPRLink()
+    this.latestRelease = await this.getFirstReleaseThatStartsWith('latest')
   }
 
   async branchAlreadyExists ({ repo, branchName }) {
@@ -129,18 +126,17 @@ class GitHub {
       })
     }
 
-    const uploadUrl = await this.octokit.repos
+    this.release = await this.octokit.repos
       .createRelease({
         owner: this.owner,
         repo: this.repo,
         tag_name: this.tagName,
         target_commitish: commit,
         name: this.tagName,
-      })
-      .then((result) => result.data.upload_url)
+      }).then((result) => result.data)
 
     await this.octokit.repos.uploadReleaseAsset({
-      url: uploadUrl,
+      url: this.release.upload_url,
       data: fs.createReadStream(this.bundleFile),
       name: this.bundleFileBasename,
       headers: {
@@ -159,17 +155,39 @@ class GitHub {
       title: this.tagName,
       head: this.tagName,
       base: ref,
-      body: `ref: ${this.latestPRLink}`,
+      body: `ref: ${this.lastPRLink}`,
     })
   }
 
-  async getCurrentReleaseNumber () {
-    const release = await this.getLatestProdRelease()
-    return Number(release.name.slice(this.prefix.length))
+  async deleteUIBundleZipFileIfExist () {
+    const uiBundleAsset = await this.getAsset(this.latestRelease, 'ui-bundle.zip')
+
+    if (uiBundleAsset) {
+      await this.octokit.rest.repos.deleteReleaseAsset({
+        owner: this.owner,
+        repo: this.repo,
+        asset_id: uiBundleAsset.id,
+      })
+    }
   }
 
-  async getLatestProdRelease () {
-    let latestRelease
+  async getAsset (release, fileName) {
+    const { data: assets } = await this.octokit.rest.repos.listReleaseAssets({
+      owner: this.owner,
+      repo: this.repo,
+      release_id: release.id,
+    })
+
+    return assets.find((asset) => asset.name === fileName)
+  }
+
+  async getCurrentReleaseNumber () {
+    const release = await this.getLastProdRelease()
+    return Number(release.name.slice(this.variant.length + 1))
+  }
+
+  async getFirstReleaseThatStartsWith (prefix) {
+    let release
     let page = 1
     do {
       const { data: releases } = await this.octokit.rest.repos.listReleases({
@@ -178,13 +196,17 @@ class GitHub {
         per_page: 100,
         page,
       })
-      latestRelease = releases.find((release) => release.name.startsWith('prod-'))
+      release = releases.find((release) => release.name.startsWith(prefix))
       page++
-    } while (!latestRelease && page <= 10) // Limit to 1000 releases
-    return latestRelease
+    } while (!release && page <= 10) // Limit to 1000 releases
+    return release
   }
 
-  async getLatestPRLink () {
+  async getLastProdRelease () {
+    return await this.getFirstReleaseThatStartsWith('prod-')
+  }
+
+  async getLastPRLink () {
     const { data: pulls } = await this.octokit.rest.pulls.list({
       owner: this.owner,
       repo: this.repo,
@@ -236,6 +258,19 @@ class GitHub {
     })
   }
 
+  async updateLatestRelease () {
+    await this.deleteUIBundleZipFileIfExist()
+    await this.octokit.repos.uploadReleaseAsset({
+      url: this.latestRelease.upload_url,
+      data: fs.createReadStream(this.bundleFile),
+      name: this.bundleFileBasename,
+      headers: {
+        'content-length': (await fs.stat(this.bundleFile)).size,
+        'content-type': 'application/zip',
+      },
+    })
+  }
+
   async updateUIBundleVer (content) {
     let contentStr = Buffer.from(content, 'base64').toString('utf8')
     contentStr = contentStr.replace(/\/prod-.+?\//, `/${this.tagName}/`)
@@ -272,6 +307,9 @@ module.exports = (dest, bundleName, owner, repo, token, updateBranch) => async (
   const gitHub = new GitHub({ dest, bundleName, owner, repo, token, updateBranch })
   await gitHub.setUp()
   await gitHub.createNextRelease()
+  if (gitHub.variant === 'prod') {
+    await gitHub.updateLatestRelease()
+  }
   // if (gitHub.variant === 'prod') {
   //   await gitHub.createPR({
   //     repo: 'docs-site-playbook',

--- a/gulp.d/tasks/release.js
+++ b/gulp.d/tasks/release.js
@@ -20,13 +20,11 @@ class GitHub {
 
   async setUp () {
     this.branchName = await this.setBranchName()
-    this.variant = this.branchName === 'master' ? 'prod' : this.branchName
     this.ref = `heads/${this.branchName}`
 
+    this.variant = this.branchName === 'master' ? 'prod' : this.branchName
     this.tagName = `${this.variant}-${await this.getCurrentReleaseNumber() + 1}`
-    this.releaseMessage = `Release ${this.tagName}`
 
-    this.lastPRLink = await this.getLastPRLink()
     this.latestRelease = await this.getLastReleaseThatStartsWith('latest')
   }
 
@@ -111,7 +109,7 @@ class GitHub {
       .createCommit({
         owner: this.owner,
         repo: this.repo,
-        message: this.releaseMessage,
+        message: `Release ${this.tagName}`,
         tree,
         parents: [commit],
       })
@@ -155,7 +153,7 @@ class GitHub {
       title: this.tagName,
       head: this.tagName,
       base: ref,
-      body: `ref: ${this.lastPRLink}`,
+      body: `ref: ${await this.getLastPRLink()}`,
     })
   }
 

--- a/gulp.d/tasks/release.js
+++ b/gulp.d/tasks/release.js
@@ -27,7 +27,7 @@ class GitHub {
     this.releaseMessage = `Release ${this.tagName}`
 
     this.lastPRLink = await this.getLastPRLink()
-    this.latestRelease = await this.getFirstReleaseThatStartsWith('latest')
+    this.latestRelease = await this.getLastReleaseThatStartsWith('latest')
   }
 
   async branchAlreadyExists ({ repo, branchName }) {
@@ -186,7 +186,7 @@ class GitHub {
     return Number(release.name.slice(this.variant.length + 1))
   }
 
-  async getFirstReleaseThatStartsWith (prefix) {
+  async getLastReleaseThatStartsWith (prefix) {
     let release
     let page = 1
     do {
@@ -203,7 +203,7 @@ class GitHub {
   }
 
   async getLastProdRelease () {
-    return await this.getFirstReleaseThatStartsWith('prod-')
+    return await this.getLastReleaseThatStartsWith('prod-')
   }
 
   async getLastPRLink () {


### PR DESCRIPTION
ref: [W-12660819](https://gus.lightning.force.com/a07EE00001Mm0HAYAZ)

add to `gulp release` command the ability to update the `ui-bundle.zip` file in the release named [latest](https://github.com/mulesoft/docs-site-ui/releases/tag/latest). This allows beta and internal (and review) sites to permanently pin to the UI bundle `https://github.com/mulesoft/docs-site-ui/releases/download/latest/ui-bundle.zip`.

also performed some code refactoring.

If you would like to test this locally, here are the steps:
1. export your Github token via `export GITHUB_TOKEN=<your token>`
2. in docs-site-ui's root project directory, run `gulp release`. Ensure that no errors are present
3. open https://github.com/mulesoft/docs-site-ui/releases and see that there is a new release named prod-* that released "now" or 1 minute ago, based on the timestamp
4. open https://github.com/mulesoft/docs-site-ui/releases/tag/latest and see that the ui-bundle.zip file has the timestamp of either "now" or 1 minute ago