### PR TITLE
[W-12703231] add heading level to search facets

### DIFF
--- a/src/partials/search/search-interface.hbs
+++ b/src/partials/search/search-interface.hbs
@@ -1,43 +1,43 @@
 {{#if env.COVEO_API_KEY}}
 <div class="search-div">
-<atomic-aria-live></atomic-aria-live>
-<atomic-search-interface 
-  id="search" 
-  fields-to-include='["mulesoftislatestversion", "mulesoftproductversion", "mulesoftversionmajor", "mulesoftversionminor", "mulesoftversionpatch", "mulesoftversionwithlatest", "product", "version"]'
-  search-hub="Documentation"
->
-  <atomic-search-layout>
-    <atomic-layout-section section="facets">
-
-      <atomic-facet facet-id="product" field="product" heading-level="1" label="Product"></atomic-facet>
-      <atomic-facet depends-on-product heading-level="1" field="mulesoftversionwithlatest" label="Version" number-of-values="20" sort-criteria="score" with-search="false"></atomic-facet>
-    </atomic-layout-section>
-    <atomic-layout-section section="main">
-      <atomic-layout-section section="status">
-        <atomic-breadbox></atomic-breadbox>
-        <atomic-query-summary></atomic-query-summary>
-        <atomic-refine-toggle></atomic-refine-toggle>
-        <atomic-sort-dropdown>
-          <atomic-sort-expression label="Relevance" expression="relevancy"></atomic-sort-expression>
-          <atomic-sort-expression label="Version (Descending)" expression="mulesoftversionmajor descending, mulesoftversionminor descending, mulesoftversionpatch descending"></atomic-sort-expression>
-        </atomic-sort-dropdown>
-        <atomic-did-you-mean></atomic-did-you-mean>
+  <atomic-aria-live></atomic-aria-live>
+  <atomic-search-interface id="search"
+    fields-to-include='["mulesoftislatestversion", "mulesoftproductversion", "mulesoftversionmajor", "mulesoftversionminor", "mulesoftversionpatch", "mulesoftversionwithlatest", "product", "version"]'
+    search-hub="Documentation">
+    <atomic-search-layout>
+      <atomic-layout-section section="facets">
+        <atomic-facet facet-id="product" field="product" heading-level="1" label="Product"></atomic-facet>
+        <atomic-facet depends-on-product facet-id="version" field="mulesoftversionwithlatest" heading-level="1"
+          label="Version" number-of-values="20" sort-criteria="score" with-search="false">
+        </atomic-facet>
       </atomic-layout-section>
-      <atomic-layout-section section="results">
-        {{!-- comment out due to issue reported in W-12600975 --}}
-        {{!-- <atomic-smart-snippet collapsed-height="70" maximum-height="70"></atomic-smart-snippet> --}}
-        <atomic-result-list image-size="icon" density="normal">
-          {{> search-result-template}}
-        </atomic-result-list>
-        <atomic-query-error></atomic-query-error>
-        <atomic-no-results></atomic-no-results>
+      <atomic-layout-section section="main">
+        <atomic-layout-section section="status">
+          <atomic-breadbox></atomic-breadbox>
+          <atomic-query-summary></atomic-query-summary>
+          <atomic-refine-toggle></atomic-refine-toggle>
+          <atomic-sort-dropdown>
+            <atomic-sort-expression label="Relevance" expression="relevancy"></atomic-sort-expression>
+            <atomic-sort-expression label="Version (Descending)"
+              expression="mulesoftversionmajor descending, mulesoftversionminor descending, mulesoftversionpatch descending"></atomic-sort-expression>
+          </atomic-sort-dropdown>
+          <atomic-did-you-mean></atomic-did-you-mean>
+        </atomic-layout-section>
+        <atomic-layout-section section="results">
+          {{!-- comment out due to issue reported in W-12600975 --}}
+          {{!-- <atomic-smart-snippet collapsed-height="70" maximum-height="70"></atomic-smart-snippet> --}}
+          <atomic-result-list image-size="icon" density="normal">
+            {{> search-result-template}}
+          </atomic-result-list>
+          <atomic-query-error></atomic-query-error>
+          <atomic-no-results></atomic-no-results>
+        </atomic-layout-section>
+        <atomic-layout-section section="pagination">
+          <atomic-pager number-of-pages="5"></atomic-pager>
+          <atomic-results-per-page></atomic-results-per-page>
+        </atomic-layout-section>
       </atomic-layout-section>
-      <atomic-layout-section section="pagination">
-        <atomic-pager number-of-pages="5"></atomic-pager>
-        <atomic-results-per-page></atomic-results-per-page>
-      </atomic-layout-section>
-    </atomic-layout-section>
-  </atomic-search-layout>
-</atomic-search-interface>
+    </atomic-search-layout>
+  </atomic-search-interface>
 </div>
 {{/if}}


### PR DESCRIPTION
ref: W-12703231

Accessibility fix. Add heading level (`<h1>` specifically) to the search facets instead of using `<div>`.

Apologies for the changes - I used an HTML formatter on the page which formatted the entire page. The only significant changes are done in lines 9 and 10 in the changed file, where `heading-level="1"` is added to both facets.