### PR TITLE
[W-12773381] fix top banner and toolbar positions in search page

### DIFF
--- a/src/css/specific/banner.css
+++ b/src/css/specific/banner.css
@@ -100,30 +100,30 @@
 }
 
 .top-banner:not(.hide) + {
-  &.flex.container > main > .toolbar {
+  &.container > main > .toolbar {
     top: var(--mobile-banner-height);
   }
 
-  &.flex.container > main > .secondary-breadcrumbs-drawer {
+  &.container > main > .secondary-breadcrumbs-drawer {
     top: calc(var(--mobile-banner-height) + var(--toolbar-height));
   }
 
-  &.flex.container > main > .notice-banner {
+  &.container > main > .notice-banner {
     top: calc(var(--mobile-banner-height) + var(--toolbar-height) + var(--breadcrumbs-drawer-height));
   }
 
   @media (--md) {
-    &.flex.container > .nav,
-    &.flex.container > .toc {
+    &.container > .nav,
+    &.container > .toc {
       max-height: calc(100vh - var(--banner-height));
       top: var(--banner-height);
     }
 
-    &.flex.container > main > .toolbar {
+    &.container > main > .toolbar {
       top: var(--banner-height);
     }
 
-    &.flex.container > main > .notice-banner {
+    &.container > main > .notice-banner {
       top: calc(var(--banner-height) + var(--toolbar-height));
     }
   }

--- a/src/layouts/default.hbs
+++ b/src/layouts/default.hbs
@@ -1,41 +1,44 @@
 <!DOCTYPE html>
-<html lang={{#if (eq (site-profile) 'jp')}}"jp"{{else}}"en"{{/if}}>
+<html lang={{#if (eq (site-profile) 'jp' )}}"jp"{{else}}"en"{{/if}}>
+
 <head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1.0">
-<title>{{{detag (or page.title 'Untitled')}}}{{#if site.title}} | {{{site.title}}}{{/if}}</title>
-{{#if page.canonicalUrl}}
-<link rel="canonical" href="{{page.canonicalUrl}}">
-{{/if}}
-{{#if page.description}}
-<meta name="description" content="{{page.description}}">
-{{/if}}
-{{#if page.keywords}}
-<meta name="keywords" content="{{page.keywords}}">
-{{/if}}
-{{#if (not (is-one-of (site-profile) 'jp' 'prod'))}}
-<meta name="robots" content="none, noarchive">
-{{/if}}
-{{> head}}
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>{{{detag (or page.title 'Untitled')}}}{{#if site.title}} | {{{site.title}}}{{/if}}</title>
+  {{#if page.canonicalUrl}}
+  <link rel="canonical" href="{{page.canonicalUrl}}">
+  {{/if}}
+  {{#if page.description}}
+  <meta name="description" content="{{page.description}}">
+  {{/if}}
+  {{#if page.keywords}}
+  <meta name="keywords" content="{{page.keywords}}">
+  {{/if}}
+  {{#if (not (is-one-of (site-profile) 'jp' 'prod'))}}
+  <meta name="robots" content="none, noarchive">
+  {{/if}}
+  {{> head}}
 </head>
+
 <body class="flex col">
-{{> header}}
+  {{> header}}
   {{#if page.attributes.connector-type}}
   <div class="flex container wrapper">
-{{> nav}}
+    {{> nav}}
     <main class="main" data-ceiling="topbar">
-{{> toolbar}}
-{{> notice-banner}}
-{{> connectors-article}}
+      {{> toolbar}}
+      {{> notice-banner}}
+      {{> connectors-article}}
     </main>
     <aside class="toc toc-sidebar scrollbar">
-{{> github}}
-{{> connectors-sidebar}}
+      {{> github}}
+      {{> connectors-sidebar}}
     </aside>
   </div>
   {{else}}
-{{> body}}
+  {{> body}}
   {{/if}}
-{{> footer}}
+  {{> footer}}
 </body>
+
 </html>

--- a/src/layouts/search-page.hbs
+++ b/src/layouts/search-page.hbs
@@ -21,10 +21,12 @@
 <body class="flex col">
 {{> header}}
 {{> top-banner}}
+<div class="container wrapper">
 <main data-ceiling="topbar">
 {{> search-toolbar}}
 {{> search-interface}}
 </main>
+</div>
 {{> footer}}
 </body>
 </html>

--- a/src/layouts/search-page.hbs
+++ b/src/layouts/search-page.hbs
@@ -1,35 +1,32 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width,initial-scale=1.0">
-    <title>{{{detag (or page.title 'Untitled')}}}{{#if site.title}} | {{{site.title}}}{{/if}}</title>
-    {{#if page.canonicalUrl}}
-    <link rel="canonical" href="{{page.canonicalUrl}}">
-    {{/if}}
-    {{#if page.description}}
-    <meta name="description" content="{{page.description}}">
-    {{/if}}
-    {{#if page.keywords}}
-    <meta name="keywords" content="{{page.keywords}}">
-    {{/if}}
-    {{#if (not (is-one-of (site-profile) 'jp' 'prod'))}}
-    <meta name="robots" content="none, noarchive">
-    {{/if}}
-    {{> head}}
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1.0">
+<title>{{{detag (or page.title 'Untitled')}}}{{#if site.title}} | {{{site.title}}}{{/if}}</title>
+{{#if page.canonicalUrl}}
+<link rel="canonical" href="{{page.canonicalUrl}}">
+{{/if}}
+{{#if page.description}}
+<meta name="description" content="{{page.description}}">
+{{/if}}
+{{#if page.keywords}}
+<meta name="keywords" content="{{page.keywords}}">
+{{/if}}
+{{#if (not (is-one-of (site-profile) 'jp' 'prod'))}}
+<meta name="robots" content="none, noarchive">
+{{/if}}
+{{> head}}
 </head>
-
 <body class="flex col">
-    {{> header}}
-    {{> top-banner}}
-    <div class="container wrapper">
-        <main data-ceiling="topbar">
-            {{> search-toolbar}}
-            {{> search-interface}}
-        </main>
-    </div>
-    {{> footer}}
+{{> header}}
+{{> top-banner}}
+<div class="container wrapper">
+<main data-ceiling="topbar">
+{{> search-toolbar}}
+{{> search-interface}}
+</main>
+</div>
+{{> footer}}
 </body>
-
 </html>

--- a/src/layouts/search-page.hbs
+++ b/src/layouts/search-page.hbs
@@ -1,32 +1,35 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1.0">
-<title>{{{detag (or page.title 'Untitled')}}}{{#if site.title}} | {{{site.title}}}{{/if}}</title>
-{{#if page.canonicalUrl}}
-<link rel="canonical" href="{{page.canonicalUrl}}">
-{{/if}}
-{{#if page.description}}
-<meta name="description" content="{{page.description}}">
-{{/if}}
-{{#if page.keywords}}
-<meta name="keywords" content="{{page.keywords}}">
-{{/if}}
-{{#if (not (is-one-of (site-profile) 'jp' 'prod'))}}
-<meta name="robots" content="none, noarchive">
-{{/if}}
-{{> head}}
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title>{{{detag (or page.title 'Untitled')}}}{{#if site.title}} | {{{site.title}}}{{/if}}</title>
+    {{#if page.canonicalUrl}}
+    <link rel="canonical" href="{{page.canonicalUrl}}">
+    {{/if}}
+    {{#if page.description}}
+    <meta name="description" content="{{page.description}}">
+    {{/if}}
+    {{#if page.keywords}}
+    <meta name="keywords" content="{{page.keywords}}">
+    {{/if}}
+    {{#if (not (is-one-of (site-profile) 'jp' 'prod'))}}
+    <meta name="robots" content="none, noarchive">
+    {{/if}}
+    {{> head}}
 </head>
+
 <body class="flex col">
-{{> header}}
-{{> top-banner}}
-<div class="container wrapper">
-<main data-ceiling="topbar">
-{{> search-toolbar}}
-{{> search-interface}}
-</main>
-</div>
-{{> footer}}
+    {{> header}}
+    {{> top-banner}}
+    <div class="container wrapper">
+        <main data-ceiling="topbar">
+            {{> search-toolbar}}
+            {{> search-interface}}
+        </main>
+    </div>
+    {{> footer}}
 </body>
+
 </html>


### PR DESCRIPTION
ref: W-12773381

fix position in the search page were scrolling down would cause the top banner to hide the search toolbar:

![Screenshot 2023-04-03 at 4 36 04 PM](https://user-images.githubusercontent.com/10934908/229649281-4705a6ff-c3f4-432b-8874-3d27e46eec33.png)

the root cause was that the search page layout is different than the other pages, so the CSS did not apply due to selector mismatching. I fixed it by adding an extra div in the search page layout around the <main> section, and then loosen up the CSS selectors.

![Screenshot 2023-04-03 at 4 40 21 PM](https://user-images.githubusercontent.com/10934908/229649810-81272d2d-1885-4469-bd3e-3d99dffa29b1.png)

Also formatted **default.hbs** with no changes. Just making it easier to read in the future.

