### PR TITLE
[W-10813720] remove skiplink for page navigation (right nav) if page nav doesn't exist

### DIFF
--- a/src/js/02-table-of-content.js
+++ b/src/js/02-table-of-content.js
@@ -217,7 +217,7 @@
     }
 
     removeTOCBlock () {
-      if (this.sidebar) this.sidebar.removeChild(this.sidebar.querySelector('.js-toc'))
+      if (this.sidebar) this.sidebar.removeChild(this.sidebar.querySelector('.aside-toc'))
     }
 
     updateExpandState () {

--- a/src/js/14-skiplink-listeners.js
+++ b/src/js/14-skiplink-listeners.js
@@ -7,6 +7,7 @@
       this.nav = document.querySelector('nav.nav')
       this.main = document.querySelector('main')
       this.aside = document.querySelector('aside')
+      this.asideToc = this.aside?.querySelector('aside-toc')
       this.toolbar = document.querySelector('.toolbar')
     }
 
@@ -38,11 +39,11 @@
           mainContentSkipLink.remove()
         }
 
-        if (this.aside) {
+        if (this.aside && this.asideToc) {
           addResizeListener(this.aside, pageNavSkipLink)
           pageNavSkipLink.addEventListener('keydown', (e) => {
             if (isVisible(this.aside)) {
-              focusOn(e, '.js-toc a')
+              focusOn(e, '.aside-toc a')
             }
           })
         } else {

--- a/src/partials/connectors/connectors-sidebar.hbs
+++ b/src/partials/connectors/connectors-sidebar.hbs
@@ -37,6 +37,6 @@
     {{/if}}
   </section>
 </div>
-<div class="js-toc">
+<div class="aside-toc">
   <nav class="toc-menu"></nav>
 </div>

--- a/src/partials/toc.hbs
+++ b/src/partials/toc.hbs
@@ -1,6 +1,6 @@
 <aside class="toc toc-sidebar scrollbar">
 {{> github}}
-  <div class="js-toc">
+  <div class="aside-toc">
     <nav class="toc-menu" aria-label="Skip to page content sections"></nav>
   </div>
 {{#if (ne page.layout '404')}}


### PR DESCRIPTION
ref: [W-10813720](https://gus.lightning.force.com/a07EE00000sL8LZYA0)

- rename `js-toc` class to `aside-toc`. Seems more fitting
- revise skiplink listener logic so that if `aside-toc` doesn't exist, skip link is removed

