### PR TITLE
[W-13008341] add top and bottom margins

### DIFF
--- a/src/css/adoc/doc.css
+++ b/src/css/adoc/doc.css
@@ -295,8 +295,8 @@
 
   /* images */
   & .image img {
-    margin-top: 24px;
     margin-bottom: 8px;
+    margin-top: 24px;
   }
 
   & kbd {

--- a/src/css/adoc/doc.css
+++ b/src/css/adoc/doc.css
@@ -295,7 +295,8 @@
 
   /* images */
   & .image img {
-    margin: 0;
+    margin-top: 24px;
+    margin-bottom: 8px;
   }
 
   & kbd {


### PR DESCRIPTION
ref: W-13008341

add top and bottom margins to images in the docs site main section to give it more space.

![Screenshot 2023-04-10 at 2 21 32 PM](https://user-images.githubusercontent.com/10934908/231001361-dc6b4238-25ab-4334-bbf8-23c3d61bcdb0.png)
