### PR TITLE
[W-13020917] remove duplicate release notes version

### DIFF
--- a/src/helpers/release-notes.js
+++ b/src/helpers/release-notes.js
@@ -104,8 +104,11 @@ const removeYear = (dateStr) => {
 
 const cleanTitle = (title) => {
   if (title) {
-    const splitList = title.split('Release Notes')
-    return splitList[0].trim()
+    return title
+      .replace(/(Release Notes.*$)/, '')
+      .trim()
+      .replace(/(([0-9])+.([0-9a-z])+(.[0-9a-z])?$)/, '')
+      .trim()
   }
 }
 


### PR DESCRIPTION
ref: W-13020917

Bug fix. Remove duplicate release notes version if it exists in the original title:

![Screenshot 2023-04-12 at 11 49 53 AM](https://user-images.githubusercontent.com/10934908/231556593-cac85cd8-8068-47d4-aa7e-ac3a3e5edfb4.png)
