### PR TITLE
[W-12632930, W-13029314] adjust close buttons + landing page font weight

### DIFF
--- a/src/css/components/button.css
+++ b/src/css/components/button.css
@@ -15,6 +15,7 @@
   padding: var(--xs);
 
   &:hover {
+    background-color: var(--light-blue);
     border-color: var(--steel-2);
     color: var(--steel-2);
   }

--- a/src/css/globals/global.css
+++ b/src/css/globals/global.css
@@ -27,10 +27,6 @@ body {
   font-family: var(--sans-serif);
   font-size: 16px;
   line-height: 1.6;
-
-  /* both min-heights are needed per https://css-tricks.com/css-fix-for-100vh-in-mobile-webkit/ */
-  min-height: 100vh;
-  min-height: -webkit-fill-available;
   word-wrap: break-word;
 
   &.no-scroll {

--- a/src/css/globals/reset.css
+++ b/src/css/globals/reset.css
@@ -46,7 +46,9 @@ textarea {
 /* reset buttons */
 button {
   &.focus,
-  &:focus {
+  &:focus,
+  &.active,
+  &:active {
     border-color: var(--secondary-navy);
     box-shadow: 0 0 0 3px rgba(0,162,223,.25);
     outline: 0;

--- a/src/css/globals/vars.css
+++ b/src/css/globals/vars.css
@@ -46,7 +46,7 @@
   /* typography */
   --heading: 'EAvantGardeBold', arial, sans-serif;
   --sans-serif: 'ESF', arial, sans-serif;
-  --sans-serif-bold: 'SFBold', arial, sans-serif;
+  --sans-serif-bold: 'ESFBold', arial, sans-serif;
   --monospace: sfmono-regular, menlo, monaco, consolas, 'Liberation Mono', 'Courier New', monospace;
   --weight-normal: 400;
   --weight-medium: 600;

--- a/src/css/globals/vars.css
+++ b/src/css/globals/vars.css
@@ -2,6 +2,8 @@
   /* colors */
   --eyebrow-gray: #6d7883;
   --secondary-navy: #002196;
+  --dark-navy: #00044c;
+  --light-blue: #e8f8ff;
   --core-blue-0: #f2fafd;
   --core-blue-1: #abe2f5;
   --core-blue-2: #48c1ed;
@@ -43,7 +45,7 @@
 
   /* typography */
   --heading: 'EAvantGardeBold', arial, sans-serif;
-  --sans-serif: 'SFRegular', arial, sans-serif;
+  --sans-serif: 'ESF', arial, sans-serif;
   --sans-serif-bold: 'SFBold', arial, sans-serif;
   --monospace: sfmono-regular, menlo, monaco, consolas, 'Liberation Mono', 'Courier New', monospace;
   --weight-normal: 400;

--- a/src/css/pages/home.css
+++ b/src/css/pages/home.css
@@ -7,7 +7,6 @@ body.home {
     padding: 0;
 
     & a {
-      font-weight: var(--weight-medium);
       text-decoration: none;
     }
 
@@ -109,7 +108,6 @@ body.home {
     & .panel {
       background: #fff;
       box-shadow: 0 10px 30px rgba(0,0,0,.1);
-      font-weight: var(--weight-medium);
       line-height: 1.3;
       padding: 30px 40px;
 
@@ -148,7 +146,6 @@ body.home {
         border-radius: 1px;
         color: var(--steel-2);
         font-size: 12px;
-        font-weight: var(--weight-medium);
         padding: 1px 4px 3px 4px;
       }
     }

--- a/src/css/pages/home.css
+++ b/src/css/pages/home.css
@@ -241,7 +241,7 @@ body.home {
   }
 }
 
-@media screen and (min-width: 350px) {
+@media screen and (min-width: 540px) {
   body.home article.doc {
     & header {
       & h1 {

--- a/src/css/pages/home.css
+++ b/src/css/pages/home.css
@@ -371,3 +371,9 @@ body.home {
     }
   }
 }
+
+#landing-page {
+  & a {
+    font-family: var(--sans-serif-bold);
+  }
+}

--- a/src/css/specific/banner.css
+++ b/src/css/specific/banner.css
@@ -42,8 +42,11 @@
     color: var(--black);
     cursor: pointer;
     float: right;
-    font-size: 20px;
-    padding: 11px 17px;
+    padding: 10px;
+
+    & img {
+      width: 15px;
+    }
   }
 
   @media (--md) {

--- a/src/css/vendor/coveo.css
+++ b/src/css/vendor/coveo.css
@@ -168,12 +168,23 @@ atomic-sort-dropdown {
 }
 
 .search-page-back-button {
+  border: 2px solid var(--secondary-navy);
+  color: var(--secondary-navy);
+  height: auto;
   margin-bottom: 10px;
-  width: 200px;
+  min-height: 38px;
+  padding: 0 10px;
+  width: fit-content;
+
+  &:hover {
+    background-color: var(--light-blue);
+    border-color: var(--dark-navy);
+    color: var(--dark-navy);
+  }
 
   & img {
-    margin-bottom: -2px !important;
-    width: 14px;
+    margin: auto;
+    width: 10px;
   }
 
   @media (min-width: 1024px) {

--- a/src/js/10-banner.js
+++ b/src/js/10-banner.js
@@ -26,7 +26,7 @@
       closeButton.title = 'Close notice banner'
       closeButton.classList.add('notice-banner-close-button')
       closeButton.classList.add('button')
-      closeButton.innerHTML = '&times;'
+      closeButton.innerHTML = '<img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt="">'
       noticeBannerDiv.insertBefore(closeButton, noticeBannerDiv.firstChild)
     }
   }

--- a/src/js/vendor/coveo.bundle.js
+++ b/src/js/vendor/coveo.bundle.js
@@ -30,6 +30,9 @@
     const searchPageBackButton = document.querySelector('.search-page-back-button')
     if (searchPageBackButton) {
       const href = getHref()
+      const helperText = `Navigate to ${href}`
+      searchPageBackButton.ariaLabel = helperText
+      searchPageBackButton.title = helperText
       searchPageBackButton.addEventListener('click', (e) => {
         window.location.href = href
         e.preventDefault()

--- a/src/js/vendor/coveo.bundle.js
+++ b/src/js/vendor/coveo.bundle.js
@@ -30,7 +30,10 @@
     const searchPageBackButton = document.querySelector('.search-page-back-button')
     if (searchPageBackButton) {
       const href = getHref()
-      searchPageBackButton.setAttribute('href', href)
+      searchPageBackButton.addEventListener('click', (e) => {
+        window.location.href = href
+        e.preventDefault()
+      })
     }
   }
 

--- a/src/layouts/home.hbs
+++ b/src/layouts/home.hbs
@@ -22,7 +22,7 @@
     {{> top-banner}}
     <div class="flex container wrapper">
         {{> nav}}
-        <main class="main" data-ceiling="topbar">
+        <main class="main" id="landing-page" data-ceiling="topbar">
             {{> toolbar}}
             {{> notice-banner}}
             {{> landing-page}}

--- a/src/partials/head/head-meta.hbs
+++ b/src/partials/head/head-meta.hbs
@@ -34,6 +34,7 @@
 {{#if (or antoraVersion site.antoraVersion)}}
 <meta name="generator" content="Antora {{or antoraVersion site.antoraVersion}}">
 {{/if}}
+<meta name="viewport" content="width=device-width, height=device-height, initial-scale=1">
 <link rel="stylesheet" href="{{uiRootPath}}/css/site.css">
 {{> marketing-styles}}
 <link rel="icon" href="{{uiRootPath}}/img/favicon.ico" type="image/x-icon">

--- a/src/partials/notice-banner/banner-for-no-longer-updated.hbs
+++ b/src/partials/notice-banner/banner-for-no-longer-updated.hbs
@@ -3,5 +3,5 @@
         We are no longer updating this version of the documentation.
         {{> banner-latest-version-snippet }}
     </p>
-    <button aria-label="Close notice banner" class="close-button" title="Close notice banner">&times;</button>
+    <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>

--- a/src/partials/notice-banner/banner-for-old-version.hbs
+++ b/src/partials/notice-banner/banner-for-old-version.hbs
@@ -3,5 +3,5 @@
         You're viewing an older version of the documentation.
         {{> banner-latest-version-snippet }}
     </p>
-    <button aria-label="Close notice banner" class="close-button" title="Close notice banner">&times;</button>
+    <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>

--- a/src/partials/notice-banner/eol-reached/banner-for-eol-reached-feature.hbs
+++ b/src/partials/notice-banner/eol-reached/banner-for-eol-reached-feature.hbs
@@ -5,5 +5,5 @@
         <a class="notice-banner-link" href="https://www.mulesoft.com/legal/versioning-back-support-policy"
             target="_blank" rel="noopener noreferrer">End of Life</a>.
     </p>
-    <button aria-label="Close notice banner" class="close-button" title="Close notice banner">&times;</button>
+    <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>

--- a/src/partials/notice-banner/eol-reached/banner-for-eol-reached-version.hbs
+++ b/src/partials/notice-banner/eol-reached/banner-for-eol-reached-version.hbs
@@ -5,5 +5,5 @@
             target="_blank" rel="noopener noreferrer">End of Life</a>.
         {{> banner-latest-version-snippet }}
     </p>
-    <button aria-label="Close notice banner" class="close-button" title="Close notice banner">&times;</button>
+    <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>

--- a/src/partials/notice-banner/eol-reached/banner-for-eol-reached.hbs
+++ b/src/partials/notice-banner/eol-reached/banner-for-eol-reached.hbs
@@ -4,5 +4,5 @@
         <a class="notice-banner-link" href="https://www.mulesoft.com/legal/versioning-back-support-policy"
             target="_blank" rel="noopener noreferrer">End of Life</a>.
     </p>
-    <button aria-label="Close notice banner" class="close-button" title="Close notice banner">&times;</button>
+    <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>

--- a/src/partials/notice-banner/eol-scheduled/banner-for-eol-scheduled-feature.hbs
+++ b/src/partials/notice-banner/eol-scheduled/banner-for-eol-scheduled-feature.hbs
@@ -4,5 +4,5 @@
         <a class="notice-banner-link" href="https://www.mulesoft.com/legal/versioning-back-support-policy"
             target="_blank" rel="noopener noreferrer">End of Life.</a>
     </p>
-    <button aria-label="Close notice banner" class="close-button" title="Close notice banner">&times;</button>
+    <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>

--- a/src/partials/notice-banner/eol-scheduled/banner-for-eol-scheduled-version.hbs
+++ b/src/partials/notice-banner/eol-scheduled/banner-for-eol-scheduled-version.hbs
@@ -5,5 +5,5 @@
             target="_blank" rel="noopener noreferrer">End of Life.</a>
         {{> banner-latest-version-snippet }}
     </p>
-    <button aria-label="Close notice banner" class="close-button" title="Close notice banner">&times;</button>
+    <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>

--- a/src/partials/notice-banner/eol-scheduled/banner-for-eol-scheduled.hbs
+++ b/src/partials/notice-banner/eol-scheduled/banner-for-eol-scheduled.hbs
@@ -4,5 +4,5 @@
         <a class="notice-banner-link" href="https://www.mulesoft.com/legal/versioning-back-support-policy"
             target="_blank" rel="noopener noreferrer">End of Life.</a>
     </p>
-    <button aria-label="Close notice banner" class="close-button" title="Close notice banner">&times;</button>
+    <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>

--- a/src/partials/notice-banner/eol-support/banner-for-eol-support-feature.hbs
+++ b/src/partials/notice-banner/eol-support/banner-for-eol-support-feature.hbs
@@ -4,5 +4,5 @@
         <a class="notice-banner-link" href="https://www.mulesoft.com/legal/versioning-back-support-policy#end-of-life-support"
             target="_blank" rel="noopener noreferrer">End of Life Support</a>.
     </p>
-    <button aria-label="Close notice banner" class="close-button" title="Close notice banner">&times;</button>
+    <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>

--- a/src/partials/notice-banner/eol-support/banner-for-eol-support-version.hbs
+++ b/src/partials/notice-banner/eol-support/banner-for-eol-support-version.hbs
@@ -5,5 +5,5 @@
             target="_blank" rel="noopener noreferrer">End of Life Support</a>.
         {{> banner-latest-version-snippet }}
     </p>
-    <button aria-label="Close notice banner" class="close-button" title="Close notice banner">&times;</button>
+    <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>

--- a/src/partials/notice-banner/eol-support/banner-for-eol-support.hbs
+++ b/src/partials/notice-banner/eol-support/banner-for-eol-support.hbs
@@ -4,5 +4,5 @@
         <a class="notice-banner-link" href="https://www.mulesoft.com/legal/versioning-back-support-policy#end-of-life-support"
             target="_blank" rel="noopener noreferrer">End of Life Support</a>.
     </p>
-    <button aria-label="Close notice banner" class="close-button" title="Close notice banner">&times;</button>
+    <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>

--- a/src/partials/notice-banner/extended-support/banner-for-extended-support-feature.hbs
+++ b/src/partials/notice-banner/extended-support/banner-for-extended-support-feature.hbs
@@ -4,5 +4,5 @@
         <a class="notice-banner-link" href="https://www.mulesoft.com/legal/versioning-back-support-policy#extended-support"
             target="_blank" rel="noopener noreferrer">Extended Support</a>.
     </p>
-    <button aria-label="Close notice banner" class="close-button" title="Close notice banner">&times;</button>
+    <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>

--- a/src/partials/notice-banner/extended-support/banner-for-extended-support-version.hbs
+++ b/src/partials/notice-banner/extended-support/banner-for-extended-support-version.hbs
@@ -5,5 +5,5 @@
             target="_blank" rel="noopener noreferrer">Extended Support</a>.
         {{> banner-latest-version-snippet }}
     </p>
-    <button aria-label="Close notice banner" class="close-button" title="Close notice banner">&times;</button>
+    <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>

--- a/src/partials/notice-banner/extended-support/banner-for-extended-support.hbs
+++ b/src/partials/notice-banner/extended-support/banner-for-extended-support.hbs
@@ -4,5 +4,5 @@
         <a class="notice-banner-link" href="https://www.mulesoft.com/legal/versioning-back-support-policy#extended-support"
             target="_blank" rel="noopener noreferrer">Extended Support</a>.
     </p>
-    <button aria-label="Close notice banner" class="close-button" title="Close notice banner">&times;</button>
+    <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>

--- a/src/partials/notice-banner/notice-banner.hbs
+++ b/src/partials/notice-banner/notice-banner.hbs
@@ -1,7 +1,7 @@
 {{#if page.attributes.notice-banner-message}}
 <div class="banner notice-banner flex">
   <p>{{page.attributes.notice-banner-message}}</p>
-  <button aria-label="Close notice banner" class="close-button" title="Close notice banner">&times;</button>
+  <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>
 {{else if (or page.componentVersion.asciidoc.attributes.supportStatus page.attributes.support-status)}} 
 {{#switch (or page.componentVersion.asciidoc.attributes.supportStatus page.attributes.support-status)}}

--- a/src/partials/search/search-result-template.hbs
+++ b/src/partials/search/search-result-template.hbs
@@ -21,7 +21,7 @@
         text-decoration: none !important;
       }
       atomic-result-link > a:not(:visited) {
-        color: #002196 !important;
+        color: #var(--secondary-navy) !important;
       }
       atomic-result-link > a:hover {
         background-color: #c0edff;

--- a/src/partials/toolbar/search-toolbar.hbs
+++ b/src/partials/toolbar/search-toolbar.hbs
@@ -1,8 +1,7 @@
 <nav aria-label="Docs Search toolbar" class="toolbar search-toolbar">
-  <a class="search-page-back-button button-primary" href="#">
-    <img loading="lazy" src="{{@root.uiRootPath}}/img/icons/arrow-back.svg" alt="">
-    Back to MuleSoft Docs
-  </a>
+  <button class="button search-page-back-button">
+    <img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""> Close
+  </button>
   <atomic-external>
     <atomic-layout-section section="search">
       <atomic-search-box></atomic-search-box>

--- a/src/partials/top-banner.hbs
+++ b/src/partials/top-banner.hbs
@@ -25,6 +25,6 @@ page.componentVersion.asciidoc.attributes.announcementMessage)
     </p>
     {{/if}}
   </div>
-  <button aria-label="Close banner" class="close-button" title="Close banner">&times;</button>
+  <button aria-label="Close banner" class="close-button" title="Close banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>
 {{/if}}


### PR DESCRIPTION
refs:
- W-12632930
- [W-13029314](https://gus.lightning.force.com/lightning/r/a07EE00001PN060YAD/view)

_all screenshots in the following sections show before on the left, and after on the right_

### search page close button

adjust wording, behavior, look.

![Screenshot 2023-04-14 at 2 18 15 PM](https://user-images.githubusercontent.com/10934908/232156599-6e62efba-b673-431b-b952-52e0efe18174.png)

### banner close buttons

update banner close buttons from using a special character (x) to using a more proper SVG image

![Screenshot 2023-04-14 at 2 19 36 PM](https://user-images.githubusercontent.com/10934908/232156786-48240e0b-b817-45af-8c92-62c56044ece1.png)

### landing page links font

added CSS to make landing page links bold

![Screenshot 2023-04-14 at 2 21 45 PM](https://user-images.githubusercontent.com/10934908/232157102-b3249fae-a88e-4356-8568-9a3fb99eec6b.png)
