### PR TITLE
[W-13065345] 2 bug fixes: image top/bottom margin + nav item width

### DIFF
--- a/src/css/adoc/doc.css
+++ b/src/css/adoc/doc.css
@@ -295,8 +295,7 @@
 
   /* images */
   & .image img {
-    margin-bottom: 8px;
-    margin-top: 24px;
+    margin: 0;
   }
 
   & kbd {

--- a/src/css/specific/nav.css
+++ b/src/css/specific/nav.css
@@ -90,20 +90,10 @@
 
 .nav-text {
   display: flex;
-  padding-right: 3%;
+  margin-right: 5%;
   text-decoration: none;
   width: -moz-available;
   width: -webkit-fill-available;
-
-  &:focus {
-    border-radius: var(--radius);
-    outline: 2px solid var(--gray) !important;
-    padding-right: 2%;
-  }
-
-  &:hover {
-    padding-right: inherit;
-  }
 }
 
 .nav-title > .nav-text,
@@ -122,6 +112,15 @@
 .nav-text:not([href]),
 .nav-item-toggle + span.nav-text {
   cursor: pointer;
+
+  &:focus {
+    border-radius: var(--radius);
+    outline: 2px solid var(--gray) !important;
+  }
+  
+  &:hover {
+    margin-right: 4%;
+  }
 }
 
 .nav-groups {

--- a/src/css/specific/nav.css
+++ b/src/css/specific/nav.css
@@ -117,7 +117,7 @@
     border-radius: var(--radius);
     outline: 2px solid var(--gray) !important;
   }
-  
+
   &:hover {
     margin-right: 4%;
   }

--- a/src/css/specific/nav.css
+++ b/src/css/specific/nav.css
@@ -119,7 +119,7 @@
   }
 
   &:hover {
-    margin-right: 4%;
+    margin-right: 3%;
   }
 }
 

--- a/src/js/17-image-margin.js
+++ b/src/js/17-image-margin.js
@@ -1,6 +1,8 @@
 ;(() => {
   'use strict'
 
+  // add extra spaces to the top and bottom of big images on the page
+
   const addMargins = (image) => {
     image.style.marginTop = '24px'
     image.style.marginBottom = '8px'

--- a/src/js/17-image-margins.js
+++ b/src/js/17-image-margins.js
@@ -1,0 +1,17 @@
+;(() => {
+  'use strict'
+
+  const addMargins = (image) => {
+    image.style.marginTop = '24px'
+    image.style.marginBottom = '8px'
+  }
+
+  const isBig = (image) => {
+    return image.height > 20
+  }
+
+  const pageImages = document.querySelectorAll('.doc span > img')
+  pageImages.forEach((image) => {
+    if (isBig(image)) addMargins(image)
+  })
+})()


### PR DESCRIPTION
ref: W-13065345

Fix 2 bugs.

### image top/bottom margin

regression bug from #369, where margins were also applying to icons. Reverted the CSS change and instead, applying a javascript to add the margins if the images are big enough

### nav item width

regression bug from #376, where extra right padding was applied to nav items that do not need that padding. Corrected the CSS so that certain nav items are excluded from having padding changes, and also adjusted the padding change values to further minimize the chance of number of lines changing
