### PR TITLE
[W-13199049 + W-13198917] enhance archive site's left nav

### DIFF
--- a/src/css/specific/nav.css
+++ b/src/css/specific/nav.css
@@ -313,6 +313,7 @@ svg.nav-icon {
   font-size: .75rem;
   max-height: 0;
   max-width: 160px;
+  min-width: 80px;
   opacity: 0;
   overflow: hidden;
   padding: var(--xs);

--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -686,6 +686,8 @@
           } else if (lastVersionData === currentVersionData) {
             navVersionMenu.appendChild(createElement('span.nav-version-label', 'Previous versions'))
           }
+        } else if (versionData === currentVersionData) {
+          navVersionMenu.appendChild(createElement('span.nav-version-label', 'Archived versions'))
         }
         const versionDataset = {
           version: versionData.version,


### PR DESCRIPTION
ref: W-13199049 + [W-13198917](https://gus.lightning.force.com/a07EE00001RK5gGYAT)

Improve the left nav for the archive site https://archive.docs.mulesoft.com/:
- set minimal width for nav items to preserve the nav item into a single line
- add "Archived Versions" as the label of the version selector to make it more clear what the versions are

Before:
![Screenshot 2023-05-17 at 11 25 51 AM](https://github.com/mulesoft/docs-site-ui/assets/10934908/fb598a4d-81ef-40df-bec7-47b7b558fc72)

After:
![Screenshot 2023-05-17 at 11 25 31 AM](https://github.com/mulesoft/docs-site-ui/assets/10934908/53c3b037-f058-46f0-b825-e2de72e03164)
