### PR TITLE
[W-13887420] bug fix - all search results have "latest version" badge

### DIFF
--- a/src/js/21-coveo-facets.js
+++ b/src/js/21-coveo-facets.js
@@ -28,7 +28,7 @@
         versionFacet.setAttribute('heading-level', 2)
         versionFacet.setAttribute('label', `${componentDisplayName} Version`)
         versionFacet.setAttribute('number-of-value', 20)
-        versionFacet.setAttribute('sort-criteria', 'alphanumericDescending')
+        versionFacet.setAttribute('sort-criteria', 'score')
         versionFacet.setAttribute('with-search', false)
         return versionFacet
       }

--- a/src/partials/head/head-meta.hbs
+++ b/src/partials/head/head-meta.hbs
@@ -28,12 +28,10 @@
 <meta name="version-patch" content="{{this.patch}}">
 {{/if}}
 {{/with}}
-<meta name="is-latest-version" content="false">
 <meta name="version-with-latest" content="{{or page.displayVersion page.version}}">
 <meta name="latest-version" content="{{page.component.latest.version}}">
 {{/if}}
 {{else}}
-<meta name="is-latest-version" content="true">
 <meta name="version-with-latest" content="{{or page.displayVersion page.version}} [latest]">
 {{/if}}
 <meta name="page-url" content="{{page.url}}">


### PR DESCRIPTION
ref: [W-13887420](https://gus.lightning.force.com/a07EE00001XcR1aYAF)

- remove page metadata that is causing the badge to show
- revert sort order for versions since the current sort order sometimes incorrectly moves older versions to the top
