### PR TITLE
[W-12981594] improve accessibility of paginations

### DIFF
--- a/src/css/components/pagination.css
+++ b/src/css/components/pagination.css
@@ -1,7 +1,7 @@
 nav.pagination {
   border-top: 1px solid var(--lume-g-color-neutral-80);
   display: flex;
-  margin-top: 5rem;
+  margin-top: 4rem;
   padding: 2rem 1rem 0;
 
   & a {
@@ -34,14 +34,23 @@ nav.pagination {
     }
 
     & a::after {
-      content: ">";
+      background-image: url("../img/icons/arrow-down.svg");
+      background-repeat: no-repeat;
+      content: " ";
+      height: 21px;
+      width: 21px;
+      transform: rotate(270deg);
     }
   }
   
   & .prev {
     & a::before {
-        content: "<";
-        transform: translateX(-100%);
+      background-image: url("../img/icons/arrow-down.svg");
+      background-repeat: no-repeat;
+      content: " ";
+      height: 21px;
+      width: 21px;
+      transform: translateX(-100%) rotate(90deg);
     }
 
     &::before {

--- a/src/partials/pagination.hbs
+++ b/src/partials/pagination.hbs
@@ -2,10 +2,10 @@
 {{#if (or page.previous page.next)}}
 <nav class="pagination">
   {{#with page.previous}}
-  <span class="prev"><a href="{{{relativize ./url}}}">{{{./content}}}</a></span>
+  <span class="prev"><a aria-label="go to the previous page: {{{./content}}}" href="{{{relativize ./url}}}">{{{./content}}}</a></span>
   {{/with}}
   {{#with page.next}}
-  <span class="next"><a href="{{{relativize ./url}}}">{{{./content}}}</a></span>
+  <span class="next"><a aria-label="go to the next page: {{{./content}}}" href="{{{relativize ./url}}}">{{{./content}}}</a></span>
   {{/with}}
 </nav>
 {{/if}}


### PR DESCRIPTION
ref: W-12981594

- for the arrow contents (`<` and `>`), replace them from characters to images, so they don't get announced by the screen readers
- add aria-labels to the links to better describe what the links mean
- slight adjustment of the top margin to bring the pagination row closer to the content