### PR TITLE
[W-13855859] add extra bottom margin

### DIFF
--- a/src/css/adoc/doc.css
+++ b/src/css/adoc/doc.css
@@ -164,6 +164,10 @@
   & aside {
     margin-bottom: var(--lg);
     margin-top: var(--lg);
+
+    &:has(.code-expand) {
+      margin-bottom: calc(var(--lg) + 26px);
+    }
   }
 
   /* links */


### PR DESCRIPTION
ref: W-13855859

add a bit more space between the code snippet and the elements below it. The following screenshot shows how it will look:

![Screenshot 2023-08-17 at 2 43 09 PM](https://github.com/mulesoft/docs-site-ui/assets/10934908/f48915a4-6c2c-475a-ba31-849de3b5937c)
