### PR TITLE
[W-13855859] adjust code block overlay height

### DIFF
--- a/src/css/adoc/doc.css
+++ b/src/css/adoc/doc.css
@@ -259,9 +259,9 @@
       }
 
       & .code-overlay {
-        background: linear-gradient(transparent 70%, white);
+        background: linear-gradient(transparent 5%, white);
         bottom: 0;
-        height: 100%;
+        height: 20%;
         left: 0;
         position: absolute;
         width: 100%;


### PR DESCRIPTION
ref: [W-13855859](https://gus.lightning.force.com/a07EE00001XKPn5YAH)

#504 added the capability for long code snippets to be collapsible. However, the overlay that added the "fading white edge" at the bottom was covering the code snippet, which means that people can't highlight the code or click the copy button until the code snippet is expanded.

This PR makes the code block overlay much shorter, which means that it is not blocking the code snippet's elements except for the very bottom, while retaining the same apperance.

<img width="486" alt="Screenshot 2023-08-21 at 7 04 35 AM" src="https://github.com/mulesoft/docs-site-ui/assets/10934908/2f0291fb-0318-4d11-a679-c0adbfedbc7f">
