### PR TITLE
W-14071110 Add spacing between paragraphs in a table cell

### DIFF
--- a/preview-site-src/elements/table.adoc
+++ b/preview-site-src/elements/table.adoc
@@ -393,3 +393,16 @@ You can use *Continue On Error* in conjunction with *Use Single Transaction*. Su
 | Multipart reader performance is enhanced by using the proper input stream implementation. | W-13099773
 |Fixed OS security vulnerabilities. | N/A
 |===
+
+== Table with multiple paragraphs in a cell
+
+[%header%autowidth.spread]
+|===
+|Property |Description
+|*Address* |Enter the address for this endpoint, such as `http://localhost:8081/file`.
+
+Here is a second paragraph in the same cell.
+
+And here is another paragraph.
+|*Response timeout* |Specify how long the endpoint must wait for a response (in ms). The default is *1000* ms.
+|===

--- a/src/css/adoc/table.css
+++ b/src/css/adoc/table.css
@@ -181,6 +181,10 @@ table:not(.connectors-table, div.admonitionblock table, div.colist table, div.pa
     padding: 10px;
   }
 
+  & td.tableblock p + p {
+    margin-top: var(--md);
+  }
+
   & .source-toolbox {
     top: 1.8rem;
   }


### PR DESCRIPTION
When there are multiple paragraphs in a table cell, the paragraphs should display space in between for legibility.

**Note**: Looking to do additional testing before submitting.