### PR TITLE
Add spacing between paragraphs in a table cell

### DIFF
--- a/preview-site-src/elements/table.adoc
+++ b/preview-site-src/elements/table.adoc
@@ -393,3 +393,16 @@ You can use *Continue On Error* in conjunction with *Use Single Transaction*. Su
 | Multipart reader performance is enhanced by using the proper input stream implementation. | W-13099773
 |Fixed OS security vulnerabilities. | N/A
 |===
+
+== Table with multiple paragraphs in a cell
+
+[%header%autowidth.spread]
+|===
+|Property |Description
+|*Address* |Enter the address for this endpoint, such as `http://localhost:8081/file`.
+
+Here is a second paragraph in the same cell.
+
+And here is another paragraph.
+|*Response timeout* |Specify how long the endpoint must wait for a response (in ms). The default is *1000* ms.
+|===

--- a/src/css/adoc/table.css
+++ b/src/css/adoc/table.css
@@ -181,6 +181,10 @@ table:not(.connectors-table, div.admonitionblock table, div.colist table, div.pa
     padding: 10px;
   }
 
+  & td.tableblock p + p {
+    margin-top: var(--md);
+  }
+
   & .source-toolbox {
     top: 1.8rem;
   }


### PR DESCRIPTION
When a table cell has multiple paragraphs, there should be spacing between the paragraphs.

**Testing**:

Added test table to preview site which displays properly:
![Screenshot 2023-10-11 at 12 19 39 PM](https://github.com/mulesoft/docs-site-ui/assets/5760201/8b8e7082-ea19-4e97-9bb0-e7676c0e5ccd)
