### PR TITLE
[W-11911033] Change section anchors to copy link button

### DIFF
--- a/src/css/adoc/doc.css
+++ b/src/css/adoc/doc.css
@@ -155,14 +155,6 @@
     }
   }
 
-  & a.link {
-    text-decoration: none;
-
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-
   & p,
   & ul,
   & ol,
@@ -191,7 +183,6 @@
       .button-primary,
       .deployment-option,
       .dw-playground-link,
-      .link,
       .notice-banner-link,
       .view-all,
       #cta *

--- a/src/css/adoc/doc.css
+++ b/src/css/adoc/doc.css
@@ -74,13 +74,13 @@
     padding-top: var(--xl);
     position: relative;
 
-    &:hover .anchor,
-    &:focus .anchor {
+    &:hover .button-copy-link,
+    &:focus .button-copy-link {
       opacity: 0.5;
       transform: scale(1);
     }
 
-    &:active .anchor {
+    &:active .button-copy-link {
       opacity: 0.75;
       transform: scale(1);
     }
@@ -96,18 +96,25 @@
     }
   }
 
-  & .anchor {
+  & .button-copy-link {
+    border: 0;
+    border-radius: 5px;
     float: right;
     height: var(--lg);
     opacity: 0;
+    padding: 1px;
     transform: scale(0.9);
     transition: opacity var(--transition-speed-sm) var(--transition-timing),
       transform var(--transition-speed-sm) var(--transition-timing);
 
     @media (--md) {
       float: none;
-      margin-left: -25px;
+      margin-left: -28px;
       position: absolute;
+    }
+
+    &:hover {
+      background-color: var(--lume-g-color-blue-80);
     }
 
     &:focus {
@@ -124,27 +131,35 @@
     width: var(--lg);
   }
 
-  & h1 .anchor {
+  & h1 .button-copy-link {
     margin-top: 11px;
   }
 
-  & h2 .anchor {
+  & h2 .button-copy-link {
     margin-top: 6px;
   }
 
-  & h3 .anchor {
+  & h3 .button-copy-link {
     margin-top: 1px;
   }
 
-  & h4 .anchor {
+  & h4 .button-copy-link {
     @media (--md) {
       margin-top: 2px;
     }
   }
 
-  & h5 .anchor {
+  & h5 .button-copy-link {
     @media (--md) {
       margin-top: 0;
+    }
+  }
+
+  & a.link {
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
     }
   }
 
@@ -176,6 +191,7 @@
       .button-primary,
       .deployment-option,
       .dw-playground-link,
+      .link,
       .notice-banner-link,
       .view-all,
       #cta *

--- a/src/css/components/popover.css
+++ b/src/css/components/popover.css
@@ -13,7 +13,8 @@
   padding-right: 15px;
 }
 
-.tippy-box[data-theme~="current-version-popover"] {
+.tippy-box[data-theme~="current-version-popover"],
+.tippy-box[data-theme~="copy-link-popover"] {
   background: var(--lume-g-color-blue-30);
   border: none;
   color: var(--tertiary);

--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -232,9 +232,7 @@
 
   const getBannerHeight = () => {
     const topBanner = document.querySelector('.top-banner')
-    return topBanner
-      ? topBanner.offsetHeight
-      : 0
+    return topBanner ? topBanner.offsetHeight : 0
   }
 
   function hideVersionMenu (menu, force) {
@@ -277,7 +275,7 @@
     return arr.slice(start, end)
   }
 
-  const coerceToArray = (val) => Array.isArray(val) ? val : [val]
+  const coerceToArray = (val) => (Array.isArray(val) ? val : [val])
 
   const clearSelected = (parentElement) => {
     const childrenElements = parentElement.querySelectorAll('button.selected')
@@ -286,7 +284,7 @@
     })
   }
 
-  const setTitle = (title) => isArchiveSite() ? `Archive ${title}` : languageMap[document.documentElement.lang].title
+  const setTitle = (title) => (isArchiveSite() ? `Archive ${title}` : languageMap[document.documentElement.lang].title)
 
   const isArchiveSite = () => window.location.host.includes('archive')
   const isBetaSite = () => isExternalBetaSite() || isInternalBetaSite() || isReviewSite()
@@ -776,19 +774,22 @@
         const iconId = 'icon-nav-component-' + component.name
         componentsAccum[component.name] = component = Object.assign({}, component, {
           iconId: document.getElementById(iconId) ? iconId : componentIconId,
-          versions: component.versions.reduce((versionsAccum, version) => {
-            const versionName = version.version === 'master' || !version.version ? '' : version.version
-            versionsAccum[versionName] = version = Object.assign({}, version, {
-              version: versionName,
-              nav: Object.assign({ items: [] }, version.sets[0]),
-            })
-            if (versionName && !version.displayVersion) version.displayVersion = versionName
-            version.sets.slice(1).forEach((set) => {
-              version.nav.items = version.nav.items.concat(set.items) // quick fix to merge multiple sets together
-            })
-            delete version.sets
-            return versionsAccum
-          }, (versions = {})),
+          versions: component.versions.reduce(
+            (versionsAccum, version) => {
+              const versionName = version.version === 'master' || !version.version ? '' : version.version
+              versionsAccum[versionName] = version = Object.assign({}, version, {
+                version: versionName,
+                nav: Object.assign({ items: [] }, version.sets[0]),
+              })
+              if (versionName && !version.displayVersion) version.displayVersion = versionName
+              version.sets.slice(1).forEach((set) => {
+                version.nav.items = version.nav.items.concat(set.items) // quick fix to merge multiple sets together
+              })
+              delete version.sets
+              return versionsAccum
+            },
+            (versions = {})
+          ),
         })
 
         if ('' in versions && Object.keys(versions).length === 1) {

--- a/src/js/18-scroll-positions.js
+++ b/src/js/18-scroll-positions.js
@@ -1,7 +1,6 @@
 ;(() => {
   'use strict'
 
-  const uiRootPath = document.getElementById('site-script').dataset.uiRootPath
   const toolbar = document.querySelector('.toolbar')
   const noticeBanner = document.querySelector('.notice-banner')
   const topBanner = document.querySelector('.top-banner')
@@ -30,18 +29,6 @@
     }, 50)
   }
 
-  const createLinkImage = (iconName, titleText) => {
-    const img = document.createElement('img')
-    if (titleText) {
-      img.alt = titleText
-      img.setAttribute('title', titleText)
-    }
-    img.setAttribute('role', 'link')
-    img.classList.add(`${iconName}-image`)
-    img.src = `${uiRootPath}/img/icons/${iconName}.svg`
-    return img
-  }
-
   const getAnchorLink = (link) => link.href.split('#')[1]
 
   const getMinHeight = () => {
@@ -60,18 +47,15 @@
         adjustScrollPosition(anchor)
       })
 
-      const headerText = anchor.parentElement.textContent
+      const parentHeading = anchor.parentElement
+      const headerText = parentHeading.textContent
       if (headerText) {
-        const anchorImg = createLinkImage('anchor', headerText)
-        anchor.appendChild(anchorImg)
-        anchor.setAttribute('aria-label', `Jump to ${headerText}`)
-
         const sidebarLinks = [...document.querySelectorAll('.toc-menu a')].filter((a) => a.textContent === headerText)
         if (sidebarLinks.length > 0) {
           sidebarLinks[0].addEventListener('click', () => {
-            adjustScrollPosition(anchor)
+            adjustScrollPosition(parentHeading)
             setTimeout(() => {
-              anchor.focus()
+              parentHeading.focus()
             }, 100)
           })
         }

--- a/src/js/23-copy-link-button.js
+++ b/src/js/23-copy-link-button.js
@@ -10,7 +10,6 @@
 
     btn.appendChild(img)
     btn.setAttribute('aria-label', copyText)
-    btn.setAttribute('data-href', href)
     btn.classList.add('button-copy-link')
     btn.addEventListener('click', copyLinkToClipboard.bind(btn, href))
     img.setAttribute('alt', copyText)
@@ -20,12 +19,7 @@
   }
 
   function copyLinkToClipboard (linkToCopy) {
-    window.navigator.clipboard.writeText(linkToCopy).then(
-      function () {
-        this.classList.add('clicked')
-      }.bind(this),
-      function () {}
-    )
+    window.navigator.clipboard.writeText(linkToCopy)
   }
 
   const convertSectAnchors = () => {

--- a/src/js/23-copy-link-button.js
+++ b/src/js/23-copy-link-button.js
@@ -28,10 +28,11 @@
       const headerText = parentHeading.textContent
       if (headerText) {
         const copyLinkBtn = createCopyLinkBtn(anchor.href)
-        parentHeading.replaceChild(copyLinkBtn, anchor);
+        parentHeading.replaceChild(copyLinkBtn, anchor)
       }
     })
   }
+
   const addCopyLinkTooltips = () => {
     document.querySelectorAll('.button-copy-link').forEach((button) => {
       createTooltip(button, 'mouseenter', 'Copy link to clipboard')
@@ -50,7 +51,7 @@
       trigger: eventType,
       theme: 'copy-link-popover',
       touchHold: true,
-      zIndex: 'var(--z-nav-mobile)'
+      zIndex: 'var(--z-nav-mobile)',
     })
   }
 

--- a/src/js/23-copy-link-button.js
+++ b/src/js/23-copy-link-button.js
@@ -34,7 +34,6 @@
       const headerText = parentHeading.textContent
       if (headerText) {
         const copyLinkBtn = createCopyLinkBtn(anchor.href)
-        //anchor.setAttribute('aria-label', `Jump to ${headerText}`)
         parentHeading.replaceChild(copyLinkBtn, anchor);
       }
     })
@@ -56,7 +55,7 @@
       placement: 'bottom',
       trigger: eventType,
       theme: 'copy-link-popover',
-      touchHold: true, // maps touch as click (for some reason)
+      touchHold: true,
       zIndex: 'var(--z-nav-mobile)'
     })
   }

--- a/src/js/23-copy-link-button.js
+++ b/src/js/23-copy-link-button.js
@@ -1,0 +1,66 @@
+;(() => {
+  'use strict'
+
+  const uiRootPath = document.getElementById('site-script').dataset.uiRootPath
+
+  const createCopyLinkBtn = (href) => {
+    const btn = document.createElement('button')
+    const img = document.createElement('img')
+    const copyText = 'Copy link to clipboard'
+
+    btn.appendChild(img)
+    btn.setAttribute('aria-label', copyText)
+    btn.setAttribute('data-href', href)
+    btn.classList.add('button-copy-link')
+    btn.addEventListener('click', copyLinkToClipboard.bind(btn, href))
+    img.setAttribute('alt', copyText)
+    img.classList.add('anchor-image')
+    img.src = `${uiRootPath}/img/icons/anchor.svg`
+    return btn
+  }
+
+  function copyLinkToClipboard (linkToCopy) {
+    window.navigator.clipboard.writeText(linkToCopy).then(
+      function () {
+        this.classList.add('clicked')
+      }.bind(this),
+      function () {}
+    )
+  }
+
+  const convertSectAnchors = () => {
+    document.querySelectorAll('.anchor').forEach((anchor) => {
+      const parentHeading = anchor.parentElement
+      const headerText = parentHeading.textContent
+      if (headerText) {
+        const copyLinkBtn = createCopyLinkBtn(anchor.href)
+        //anchor.setAttribute('aria-label', `Jump to ${headerText}`)
+        parentHeading.replaceChild(copyLinkBtn, anchor);
+      }
+    })
+  }
+  const addCopyLinkTooltips = () => {
+    document.querySelectorAll('.button-copy-link').forEach((button) => {
+      createTooltip(button, 'mouseenter', 'Copy link to clipboard')
+      createTooltip(button, 'click', 'Copied')
+    })
+  }
+
+  const createTooltip = (btn, eventType, msg) => {
+    tippy(btn, {
+      arrow: tippy.roundArrow,
+      animation: 'shift-away',
+      content: msg,
+      delay: 200,
+      maxWidth: 240,
+      placement: 'bottom',
+      trigger: eventType,
+      theme: 'copy-link-popover',
+      touchHold: true, // maps touch as click (for some reason)
+      zIndex: 'var(--z-nav-mobile)'
+    })
+  }
+
+  convertSectAnchors()
+  addCopyLinkTooltips()
+})()

--- a/src/js/vendor/icondefs.js
+++ b/src/js/vendor/icondefs.js
@@ -1101,25 +1101,33 @@
   ]
   const icondefs = Object.assign(document.createElement('div'), { id: 'icondefs', hidden: true })
   icondefs.appendChild(
-    defs.reduce(function (parent, icondef) {
-      const symbol = Object.assign(document.createElementNS('http://www.w3.org/2000/svg', 'symbol'), { id: icondef.id })
-      symbol.setAttribute('viewBox', icondef.viewBox)
-      const contents = icondef.contents || icondef.paths || [icondef.path]
-      if (Array.isArray(contents)) {
-        contents.forEach(function (props) {
-          symbol.appendChild(
-            Object.entries(props).reduce(function (tag, prop) {
-              tag.setAttribute(prop[0], prop[1])
-              return tag
-            }, document.createElementNS('http://www.w3.org/2000/svg', 'path'))
-          )
+    defs.reduce(
+      function (parent, icondef) {
+        const symbol = Object.assign(document.createElementNS('http://www.w3.org/2000/svg', 'symbol'), {
+          id: icondef.id,
         })
-      } else {
-        symbol.innerHTML = contents
-      }
-      parent.appendChild(symbol)
-      return parent
-    }, document.createElementNS('http://www.w3.org/2000/svg', 'svg'))
+        symbol.setAttribute('viewBox', icondef.viewBox)
+        const contents = icondef.contents || icondef.paths || [icondef.path]
+        if (Array.isArray(contents)) {
+          contents.forEach(function (props) {
+            symbol.appendChild(
+              Object.entries(props).reduce(
+                function (tag, prop) {
+                  tag.setAttribute(prop[0], prop[1])
+                  return tag
+                },
+                document.createElementNS('http://www.w3.org/2000/svg', 'path')
+              )
+            )
+          })
+        } else {
+          symbol.innerHTML = contents
+        }
+        parent.appendChild(symbol)
+        return parent
+      },
+      document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    )
   )
   document.body.appendChild(icondefs)
 })()


### PR DESCRIPTION
Experimented with multiple options including the proposals in the work item. In the end, I matched the Salesforce Docs functionality:
<https://sfdocs-help.herokuapp.com/docs/success/sfdocs/guide/prerequisites.html#git-and-github>

Here's what that looks like:

On hover:
![Screenshot 2023-10-20 at 9 46 23 AM](https://github.com/mulesoft/docs-site-ui/assets/5760201/1de948a5-8207-41a5-bc6d-8ac81963e6f5)

On click:
![Screenshot 2023-10-20 at 9 46 29 AM](https://github.com/mulesoft/docs-site-ui/assets/5760201/1ac579a0-70e8-4fa2-b94c-0f079cbe0135)

Testing:

* Confirmed copying to clipboard succeeds.
* Confirmed display of tooltips on mobile, medium, and large screens.
* Confirmed keyboard navigation works as expected. (You can tab to focus and pressing enter copies to clipboard.)