### PR TITLE
[W-14080808] Fix: Code snippets display incorrectly in callout lists

### DIFF
--- a/src/css/adoc/doc.css
+++ b/src/css/adoc/doc.css
@@ -305,7 +305,7 @@
   }
 
   & p code,
-  .calloutlist code {
+  & .calloutlist code {
     background: var(--aluminum-1);
     border: 1px solid var(--aluminum-3);
     border-radius: 2px;

--- a/src/css/adoc/doc.css
+++ b/src/css/adoc/doc.css
@@ -304,7 +304,8 @@
     }
   }
 
-  & p code {
+  & p code,
+  .calloutlist code {
     background: var(--aluminum-1);
     border: 1px solid var(--aluminum-3);
     border-radius: 2px;


### PR DESCRIPTION
Code snippets in callout lists should display the border and light background that all other inline code snippets display.

Note that an alternate fix would have been to change the CSS selector to `& code` directly (to match all code snippets in the doc). I confirmed that works as well, but I was wary of unintended consequences, so I kept things scoped it down. If the broader scope is preferred, LMK and I can do that instead.

Note that I went ahead and confirmed during testing that code snippets already display correctly (with the background) in all other lists and tables.

**Before fix**

![Screenshot 2023-09-06 at 15 15 30](https://github.com/mulesoft/docs-site-ui/assets/5760201/55c73ab7-549c-4fb8-aa97-d554afa2236a)

**After fix**

![Screenshot 2023-10-23 at 12 17 59 PM](https://github.com/mulesoft/docs-site-ui/assets/5760201/67e3bf55-761f-40c0-9e13-c7150d9ce8bf)


