### PR TITLE
[W-12474663] rename "popular topics" to "trending topics" to match SF 

### DIFF
--- a/src/partials/landing-page/landing-page.hbs
+++ b/src/partials/landing-page/landing-page.hbs
@@ -9,7 +9,7 @@
     {{else}}
     {{> latest-releases}}
     {{/if}}
-    {{> popular-topics}}
+    {{> trending-topics}}
   </div>
   {{{page.contents.the-road}}}
   <footer>

--- a/src/partials/landing-page/trending-topics.hbs
+++ b/src/partials/landing-page/trending-topics.hbs
@@ -1,8 +1,7 @@
 <div class='panel'>
     <div class="sect2">
         <atomic-recs-interface id="recs" pipeline="MS Docs Site - Popular Topics" search-hub="Popular Topics">
-            {{!-- number-of-recommendations seems buggy. We want 7 items but can't specify 7 directly, only another number (like 10) would yield 7 results. Please test for the exact number in the preview site. --}}
-            <atomic-recs-list density="compact" heading-level=2 label="Popular Topics" number-of-recommendations=10>
+            <atomic-recs-list density="compact" heading-level=2 label="Trending Topics" number-of-recommendations=7>
                 <atomic-recs-result-template>
                     <template>
                         <style>


### PR DESCRIPTION
ref: [W-12474663](https://gus.lightning.force.com/a07EE00001KTGkvYAH)

- requested by Hanna via [this Slack message](https://salesforce-internal.slack.com/archives/G02H6FZJD/p1698188329180309?thread_ts=1693416547.865229&cid=G02H6FZJD) to rename the "Popular Topics" section to "Trending Topics"
- fix the number of recommendations to 7

![Screenshot 2023-10-25 at 7 25 46 AM](https://github.com/mulesoft/docs-site-ui/assets/10934908/be2c4507-235c-4120-b923-19edbb925dbc)
