### PR TITLE
[W-14086638] add version to breadcrumbs + separate Trending Topics with Coveo UA/Search 

### DIFF
--- a/src/partials/footer/footer-content-jp.hbs
+++ b/src/partials/footer/footer-content-jp.hbs
@@ -57,7 +57,7 @@
                       <li> <a href="https://www.mulesoft.com/jp/contact">&#12362;&#21839;&#12356;&#21512;&#12431;&#12379;</a></li>
                       <li> <a href="https://www.mulesoft.com/jp/integration-partner/finder">&#12497;&#12540;&#12488;&#12490;&#12540;</a></li>
                       <li> <a href="https://www.mulesoft.com/jp/events">&#12452;&#12505;&#12531;&#12488;</a></li>
-                      <li> <a href="https://www.salesforce.com/jp/company/careers/japan/">Careers</a></li>
+                      <li> <a href="https://www.salesforce.com/jp/company/careers/japan/" target="_blank">Careers</a></li>
                     </ul>
                   </li>
                 </ul>

--- a/src/partials/head/head-scripts.hbs
+++ b/src/partials/head/head-scripts.hbs
@@ -68,6 +68,19 @@ see https://segment.com/docs/connections/sources/catalog/libraries/website/javas
       });
     }
 
+    const organizationId = "mulesoftprodqzggq6re";
+    const accessToken = "{{env.COVEO_API_KEY}}";
+
+    const isProdSite = (hostname) => hostname === "docs.mulesoft.com";
+
+    initSearch(organizationId, accessToken);
+    if (isProdSite(window.location.hostname)) initCoveoUserAnalytics(organizationId, accessToken);
+  })();
+</script>
+{{/if}}
+
+<script nonce="**CSP_NONCE**">
+  (async () => {
     async function initContentRecommendations (organizationId, accessToken) {
       if (onHomePage(window.location.pathname)) {
         await customElements.whenDefined('atomic-recs-interface');
@@ -83,17 +96,13 @@ see https://segment.com/docs/connections/sources/catalog/libraries/website/javas
     }
 
     const organizationId = "mulesoftprodqzggq6re";
-    const accessToken = "{{env.COVEO_API_KEY}}";
     const crToken = "xxb149e86e-a23c-43f6-9840-95d0bfa55830"; // no need to hide this token - it has extremely limited privilege and will show in the source code anyway
-    const isProdSite = (hostname) => hostname === "docs.mulesoft.com";
+
     const onHomePage = (pathName) => pathName === '/' || pathName.endsWith('/general/');
 
-    initSearch(organizationId, accessToken);
     initContentRecommendations(organizationId, crToken);
-    if (isProdSite(window.location.hostname)) initCoveoUserAnalytics(organizationId, accessToken);
   })();
 </script>
-{{/if}}
 
 {{!-- The two blocks scripts are needed for hypothesis apps to open in the review site --}}
 {{#if (eq (site-profile) 'review' )}}

--- a/src/partials/toolbar/breadcrumbs.hbs
+++ b/src/partials/toolbar/breadcrumbs.hbs
@@ -22,13 +22,13 @@
   {{/with}}
   {{#each page.breadcrumbs}}
   {{#if (eq ./urlType 'internal')}}
-  {{#if (eq ./url @root.page.url)}}
-  <li class="flex align-center li">
-    <p>{{{./content}}}</p>
-  </li>
-  {{else if (ne ./url @root.page.breadcrumbs.0.url)}}
-  <li class="flex align-center li"><a class="link" href="{{{relativize ./url}}}">{{{./content}}}</a></li>
-  {{/if}}
+    {{#if (eq ./url @root.page.url)}}
+    <li class="flex align-center li">
+      <p>{{{./content}}}{{#if (and (ends-with ./url "index.html") (not (is-null @root.page.version)))}} ({{ @root.page.version }}){{/if}}</p>
+    </li>
+    {{else if (ne ./url @root.page.breadcrumbs.0.url)}}
+    <li class="flex align-center li"><a class="link" href="{{{relativize ./url}}}">{{{./content}}}</a></li>
+    {{/if}}
   {{/if}}
   {{/each}}
 {{/if}}

--- a/src/partials/toolbar/breadcrumbs.hbs
+++ b/src/partials/toolbar/breadcrumbs.hbs
@@ -17,7 +17,7 @@
   </li>
   {{#with page.componentVersion}}
   {{#if (and ./title (not ./root) (not (is-one-of ./title 'Home' 'ホーム')) (ne ./url @root.page.url))}}
-  <li class="flex align-center li"><a class="link" href="{{{relativize ./url}}}">{{{./title}}}</a></li>
+  <li class="flex align-center li"><a class="link" href="{{{relativize ./url}}}">{{{./title}}}{{#if (not (is-null @root.page.version))}} ({{ @root.page.version }}){{/if}}</a></li>
   {{/if}}
   {{/with}}
   {{#each page.breadcrumbs}}


### PR DESCRIPTION
ref: W-14086638

- add version to breadcrumbs so that it's easier for users to see what the version they are currently in
  ![Screenshot 2023-10-30 at 11 31 26 AM](https://github.com/mulesoft/docs-site-ui/assets/10934908/fb538198-12cf-4f08-916c-5f8ce66b9331)
- separate the Coveo scripts into 2 blocks: 1 for Trending Topics, and another for Coveo User Analytics+Search. This fixes the issue where internal beta sites cannot displaying trending topics because they weren't built with the Coveo API search key (on purpose, to avoid hitting usage quota)