### PR TITLE
[W-14400837] revise survey ID logic + clean up

### DIFF
--- a/gulp.d/tasks/build.js
+++ b/gulp.d/tasks/build.js
@@ -56,6 +56,7 @@ module.exports = (src, dest, preview) => () => {
     vfs
       .src('js/+([0-9])-*.js', { ...opts, sourcemaps })
       .pipe(replace(/'includeLocMessagesAtBuildtime'/g, fs.readFileSync(`${src}/locales/messages.json`, 'utf-8')))
+      .pipe(replace(/'feedbackQuestions'/g, fs.readFileSync(`${src}/locales/feedback-questions.json`, 'utf-8')))
       .pipe(uglify())
       .pipe(concat('js/site.js')),
     vfs

--- a/gulp.d/tasks/build.js
+++ b/gulp.d/tasks/build.js
@@ -57,6 +57,7 @@ module.exports = (src, dest, preview) => () => {
       .src('js/+([0-9])-*.js', { ...opts, sourcemaps })
       .pipe(replace(/'includeLocMessagesAtBuildtime'/g, fs.readFileSync(`${src}/locales/messages.json`, 'utf-8')))
       .pipe(replace(/'feedbackQuestions'/g, fs.readFileSync(`${src}/locales/feedback-questions.json`, 'utf-8')))
+      .pipe(replace(/'surveyIDs'/g, fs.readFileSync(`${src}/locales/survey-ids.json`, 'utf-8')))
       .pipe(uglify())
       .pipe(concat('js/site.js')),
     vfs

--- a/src/js/04-feedback.js
+++ b/src/js/04-feedback.js
@@ -145,11 +145,12 @@
 
   const getSurveyID = (baseURL) => {
     const surveyIDsSet = 'surveyIDs'
-    const fallbackSurveyID = 'mulesoft_docs_misc'
+    const fallbackSurveyID = 'others'
     const lang = document.documentElement.lang
-    return Object.hasOwn(surveyIDsSet[lang], baseURL)
+    const surveyIDLabel = Object.hasOwn(surveyIDsSet[lang], baseURL)
       ? surveyIDsSet[lang][baseURL]
       : fallbackSurveyID
+    return `mulesoft_docs_${surveyIDLabel}`
   }
 
   const isHidden = (element) => element.offsetParent === null

--- a/src/js/04-feedback.js
+++ b/src/js/04-feedback.js
@@ -6,23 +6,13 @@
 
   const formSubmitAPIVersion = 'v1'
 
-  const questionsMap = {
-    yes: {
-      legend: 'Thanks for the feedback! What made this article helpful? (Please check at least 1 checkbox.)',
-      is_accurate: 'Contains accurate information',
-      is_comprehensive: 'Includes all of the information I need',
-      is_clear: 'Easy to understand, with clear explanations and visuals',
-      other: 'Something else',
-    },
-    no: {
-      legend: "We're sorry to hear that. How can we improve this article? (Please check at least 1 checkbox.),",
-      is_accurate: 'Contains inaccurate or outdated information',
-      is_comprehensive: 'Missing important information',
-      is_clear: 'Confusing or difficult to understand',
-      is_descriptive: "The article is OK, but I don't like how the product described works",
-      other: 'Something else',
-    },
-  }
+  const questionSets = 'feedbackQuestions'
+
+  const questionSetVersion = Object.hasOwn(questionSets, formSubmitAPIVersion)
+    ? formSubmitAPIVersion
+    : 'v1'
+
+  const questionsMap = questionSets[questionSetVersion]
 
   const feedbackAckMsgSpan = feedbackCard.querySelector('span#feedback-ack')
   const feedbackOptionButtons = feedbackCard.querySelectorAll('div.feedback-options button')
@@ -104,8 +94,8 @@
 
   const atLeastOneCheckboxChecked = (feedbackForm) => {
     const checkboxes = feedbackForm.querySelectorAll('input[type="checkbox"]')
-    for (let i = 0; i < checkboxes.length; i++) {
-      if (!isHidden(checkboxes[i]) && checkboxes[i].checked) return true
+    for (const checkbox of checkboxes) {
+      if (!isHidden(checkbox) && checkbox.checked) return true
     }
   }
 

--- a/src/js/04-feedback.js
+++ b/src/js/04-feedback.js
@@ -147,9 +147,7 @@
     const surveyIDsSet = 'surveyIDs'
     const fallbackSurveyID = 'others'
     const lang = document.documentElement.lang
-    const surveyIDLabel = Object.hasOwn(surveyIDsSet[lang], baseURL)
-      ? surveyIDsSet[lang][baseURL]
-      : fallbackSurveyID
+    const surveyIDLabel = Object.hasOwn(surveyIDsSet[lang], baseURL) ? surveyIDsSet[lang][baseURL] : fallbackSurveyID
     return `mulesoft_docs_${surveyIDLabel}`
   }
 

--- a/src/js/04-feedback.js
+++ b/src/js/04-feedback.js
@@ -129,11 +129,6 @@
     return label
   }
 
-  const getBackendEndpoint = () => {
-    const endpoint = `/api/${formSubmitAPIVersion}/form-submit`
-    return isProdSite() ? endpoint : `${endpoint}?staging=true`
-  }
-
   const getCheckboxFields = () => Object.keys(questionsMap.no)
 
   const getCurrentUTCTime = () => {
@@ -157,7 +152,6 @@
       : fallbackSurveyID
   }
 
-  const isProdSite = () => window.location.host === 'docs.mulesoft.com'
   const isHidden = (element) => element.offsetParent === null
 
   const populateForm = (feedbackFieldSet, yes) => {
@@ -176,9 +170,9 @@
 
   const submitFeedbackToBackend = (form) => {
     const body = createBody(form)
-    const backendEndpoint = getBackendEndpoint()
+
     /* eslint-disable */
-    fetch(backendEndpoint, {
+    fetch(`/api/${formSubmitAPIVersion}/form-submit`, {
       body,
       cache: 'no-cache',
       headers: {

--- a/src/js/04-feedback.js
+++ b/src/js/04-feedback.js
@@ -7,12 +7,7 @@
   const formSubmitAPIVersion = 'v1'
 
   const questionSets = 'feedbackQuestions'
-
-  const questionSetVersion = Object.hasOwn(questionSets, formSubmitAPIVersion)
-    ? formSubmitAPIVersion
-    : 'v1'
-
-  const questionsMap = questionSets[questionSetVersion]
+  const questionsMap = questionSets[formSubmitAPIVersion]
 
   const feedbackAckMsgSpan = feedbackCard.querySelector('span#feedback-ack')
   const feedbackOptionButtons = feedbackCard.querySelectorAll('div.feedback-options button')
@@ -108,7 +103,7 @@
       is_helpful: selectedThumbDirection ? 'yes' : 'no',
       page_path: document.location.pathname,
       created_time: getCurrentUTCTime(),
-      survey_id: 'mulesoft_docs',
+      survey_id: getSurveyID(window.location.host),
       survey_version: formSubmitAPIVersion,
     }
 
@@ -148,9 +143,18 @@
 
   const getFirstVisibleFocusableChildElement = (element) => {
     const inputs = element.querySelectorAll('input')
-    for (let i = 0; i < inputs.length; i++) {
-      if (!isHidden(inputs[i])) return inputs[i]
+    for (const input of inputs) {
+      if (!isHidden(input)) return input
     }
+  }
+
+  const getSurveyID = (baseURL) => {
+    const surveyIDsSet = 'surveyIDs'
+    const fallbackSurveyID = 'mulesoft_docs_misc'
+    const lang = document.documentElement.lang
+    return Object.hasOwn(surveyIDsSet[lang], baseURL)
+      ? surveyIDsSet[lang][baseURL]
+      : fallbackSurveyID
   }
 
   const isProdSite = () => window.location.host === 'docs.mulesoft.com'

--- a/src/locales/feedback-questions.json
+++ b/src/locales/feedback-questions.json
@@ -1,0 +1,19 @@
+{
+  "v1": {
+    "yes": {
+      "legend": "Thanks for the feedback! What made this article helpful? (Please check at least 1 checkbox.)",
+      "is_accurate": "Contains accurate information",
+      "is_comprehensive": "Includes all of the information I need",
+      "is_clear": "Easy to understand with clear explanations and visuals",
+      "other": "Something else"
+    },
+    "no": {
+      "legend": "We're sorry to hear that. How can we improve this article? (Please check at least 1 checkbox.)",
+      "is_accurate": "Contains inaccurate or outdated information",
+      "is_comprehensive": "Missing important information",
+      "is_clear": "Confusing or difficult to understand",
+      "is_descriptive": "The article is OK, but I don't like how the product described works",
+      "other": "Something else"
+    }
+  }
+}

--- a/src/locales/survey-ids.json
+++ b/src/locales/survey-ids.json
@@ -1,13 +1,13 @@
 {
     "en": {
-        "docs.mulesoft.com": "mulesoft_docs",
-        "beta.docs.mulesoft.com": "mulesoft_docs_external_beta",
-        "dev-docs-internal.kqa.msap.io": "mulesoft_docs_internal_beta",
-        "dev-docs-internal.kdev.msap.io": "mulesoft_docs_internal_beta",
-        "dev-docs-review.kqa.msap.io": "mulesoft_docs_review",
-        "dev-docs-review.kdev.msap.io": "mulesoft_docs_review"
+        "docs.mulesoft.com": "en",
+        "beta.docs.mulesoft.com": "external_beta",
+        "dev-docs-internal.kqa.msap.io": "internal_beta",
+        "dev-docs-internal.kdev.msap.io": "internal_beta",
+        "dev-docs-review.kqa.msap.io": "review",
+        "dev-docs-review.kdev.msap.io": "review"
     },
     "jp": {
-        "docs.mulesoft.com": "mulesoft_docs_jp"
+        "docs.mulesoft.com": "jp"
     }
 }

--- a/src/locales/survey-ids.json
+++ b/src/locales/survey-ids.json
@@ -1,0 +1,13 @@
+{
+    "en": {
+        "docs.mulesoft.com": "mulesoft_docs",
+        "beta.docs.mulesoft.com": "mulesoft_docs_external_beta",
+        "dev-docs-internal.kqa.msap.io": "mulesoft_docs_internal_beta",
+        "dev-docs-internal.kdev.msap.io": "mulesoft_docs_internal_beta",
+        "dev-docs-review.kqa.msap.io": "mulesoft_docs_review",
+        "dev-docs-review.kdev.msap.io": "mulesoft_docs_review"
+    },
+    "jp": {
+        "docs.mulesoft.com": "mulesoft_docs_jp"
+    }
+}


### PR DESCRIPTION
ref: W-14400837

This PR has 2 purposes: separating survey IDs for different MuleSoft sites and cleaning up.

## Separate survey IDs

Revert the logic of #583 where prod site has its own ID and other sites use the same. Now each site type gets its own!

## Clean up

- Use the same implementation from #576 to move the feedback questions into its own JSON file
- Change some for loops to for-of

## Question

Should I have created another folder for the new json files instead of using **locale/**?