### PR TITLE
[W-14086638] hide certain versions in breadcrumbs

### DIFF
--- a/src/partials/head/head-meta.hbs
+++ b/src/partials/head/head-meta.hbs
@@ -20,7 +20,7 @@
     <meta name="product" content="{{page.component.title}}">
 {{/if}}
 
-{{#if (and page.version (not (is-one-of page.version 'default' 'latest' 'master')))}}
+{{#if (and page.version (not (is-one-of page.version 'default' 'latest' 'master' '~')))}}
     <meta name="version" content="{{or page.displayVersion page.version}}">
     {{#if (eq page.component.latest.version page.version)}}
         <meta name="is-latest-version" content="true">

--- a/src/partials/toolbar/breadcrumbs.hbs
+++ b/src/partials/toolbar/breadcrumbs.hbs
@@ -17,14 +17,14 @@
   </li>
   {{#with page.componentVersion}}
   {{#if (and ./title (not ./root) (not (is-one-of ./title 'Home' 'ホーム')) (ne ./url @root.page.url))}}
-  <li class="flex align-center li"><a class="link" href="{{{relativize ./url}}}">{{{./title}}}{{#if (not (is-null @root.page.version))}} ({{ @root.page.version }}){{/if}}</a></li>
+  <li class="flex align-center li"><a class="link" href="{{{relativize ./url}}}">{{{./title}}}{{#if (and (not (is-null @root.page.version)) (not (is-one-of @root.page.version 'default' 'latest' 'master')))}} ({{ @root.page.version }}){{/if}}</a></li>
   {{/if}}
   {{/with}}
   {{#each page.breadcrumbs}}
   {{#if (eq ./urlType 'internal')}}
     {{#if (eq ./url @root.page.url)}}
     <li class="flex align-center li">
-      <p>{{{./content}}}{{#if (and (ends-with ./url "index.html") (not (is-null @root.page.version)))}} ({{ @root.page.version }}){{/if}}</p>
+      <p>{{{./content}}}{{#if (and (not (is-null @root.page.version)) (not (is-one-of @root.page.version 'default' 'latest' 'master')))}} ({{ @root.page.version }}){{/if}}</p>
     </li>
     {{else if (ne ./url @root.page.breadcrumbs.0.url)}}
     <li class="flex align-center li"><a class="link" href="{{{relativize ./url}}}">{{{./content}}}</a></li>

--- a/src/partials/toolbar/breadcrumbs.hbs
+++ b/src/partials/toolbar/breadcrumbs.hbs
@@ -17,14 +17,14 @@
   </li>
   {{#with page.componentVersion}}
   {{#if (and ./title (not ./root) (not (is-one-of ./title 'Home' 'ホーム')) (ne ./url @root.page.url))}}
-  <li class="flex align-center li"><a class="link" href="{{{relativize ./url}}}">{{{./title}}}{{#if (and (not (is-null @root.page.version)) (not (is-one-of @root.page.version 'default' 'latest' 'master')))}} ({{ @root.page.version }}){{/if}}</a></li>
+  <li class="flex align-center li"><a class="link" href="{{{relativize ./url}}}">{{{./title}}}{{#if (and (not (is-null @root.page.version)) (not (is-one-of @root.page.version 'default' 'latest' 'master' '~')))}} ({{ @root.page.version }}){{/if}}</a></li>
   {{/if}}
   {{/with}}
   {{#each page.breadcrumbs}}
   {{#if (eq ./urlType 'internal')}}
     {{#if (eq ./url @root.page.url)}}
     <li class="flex align-center li">
-      <p>{{{./content}}}{{#if (and (not (is-null @root.page.version)) (not (is-one-of @root.page.version 'default' 'latest' 'master')))}} ({{ @root.page.version }}){{/if}}</p>
+      <p>{{{./content}}}{{#if (and (not (is-null @root.page.version)) (not (is-one-of @root.page.version 'default' 'latest' 'master' '~')))}} ({{ @root.page.version }}){{/if}}</p>
     </li>
     {{else if (ne ./url @root.page.breadcrumbs.0.url)}}
     <li class="flex align-center li"><a class="link" href="{{{relativize ./url}}}">{{{./content}}}</a></li>


### PR DESCRIPTION
slight fix to #581. Fix a bug where certain versions like "default", "latest", "master", and "~" from showing up in the breadcrumbs (like in the following screenshot):

<img width="382" alt="Screenshot 2023-11-02 at 10 08 45 AM" src="https://github.com/mulesoft/docs-site-ui/assets/10934908/3c650bf9-957d-4365-92cb-a99479320bc4">
