### PR TITLE
[W-14416061] add version to breadcrumbs root label + remove "latest release" section from JP site

### DIFF
--- a/preview-site-src/ui-model.yml
+++ b/preview-site-src/ui-model.yml
@@ -10,7 +10,10 @@ site:
   url: &index_url /
   homeUrl: *index_url
   title: MuleSoft Documentation
-  keys: {}
+  keys: {
+  ## uncomment the following line to switch site-profile to jp
+    # siteProfile: 'jp'
+  }
   components:
     general:
       latest: &general_latest

--- a/src/css/pages/home.css
+++ b/src/css/pages/home.css
@@ -107,6 +107,12 @@ body.home {
       line-height: 1.3;
       padding: 30px 40px;
 
+      &.single-panel {
+        margin: -50px auto 0;
+        max-width: 400px;
+        position: relative;
+      }
+
       & h2 {
         color: #000;
         font-size: 22px;

--- a/src/partials/landing-page/landing-page.hbs
+++ b/src/partials/landing-page/landing-page.hbs
@@ -4,7 +4,7 @@
     {{{page.contents.cta}}}
   </header>
   {{#if (eq (site-profile) 'jp' )}}
-  <div class='panel'>
+  <div class='panel single-panel'>
     {{{page.contents.popular-topics}}}
   </div>
   {{else}}

--- a/src/partials/landing-page/landing-page.hbs
+++ b/src/partials/landing-page/landing-page.hbs
@@ -3,20 +3,15 @@
     <h1 class='page'>{{{page.title}}}</h1>
     {{{page.contents.cta}}}
   </header>
-  <div class='panels'>
-    {{#if preview}}
-      {{> contributor-signatures}}
-    {{else}}
-      {{> latest-releases}}
-    {{/if}}
-    {{#if (eq (site-profile) 'jp' )}}
-      <div class='panel'>
-        {{{page.contents.popular-topics}}}
-      </div>
-    {{else}}
-      {{> trending-topics}}
-    {{/if}}
+  {{#if (eq (site-profile) 'jp' )}}
+  <div class='panel'>
+    {{{page.contents.popular-topics}}}
   </div>
+  {{else}}
+  <div class='panels'>
+    {{> trending-topics}}
+  </div>
+  {{/if}}
   {{{page.contents.the-road}}}
   <footer>
     {{{page.contents.more-resources}}}

--- a/src/partials/toolbar/breadcrumbs.hbs
+++ b/src/partials/toolbar/breadcrumbs.hbs
@@ -24,7 +24,7 @@
   {{#if (eq ./urlType 'internal')}}
     {{#if (eq ./url @root.page.url)}}
     <li class="flex align-center li">
-      <p>{{{./content}}}{{#if (and (ends-with ./url "index.html") (not (is-null @root.page.version)) (not (is-one-of @root.page.version 'default' 'latest' 'master' '~')))}} ({{ @root.page.version }}){{/if}}</p>
+      <p>{{{./content}}}{{#if (or (eq ./url @root.page.breadcrumbs.0.url) (and (ends-with ./url "index.html") (not (is-null @root.page.version)) (not (is-one-of @root.page.version 'default' 'latest' 'master' '~'))))}} ({{ @root.page.version }}){{/if}}</p>
     </li>
     {{else if (ne ./url @root.page.breadcrumbs.0.url)}}
     <li class="flex align-center li"><a class="link" href="{{{relativize ./url}}}">{{{./content}}}</a></li>


### PR DESCRIPTION
ref: [W-14416061](https://gus.lightning.force.com/a07EE00001diY5cYAE)

## Breadcrumbs

A continuation of #585.

If the page is the index page of a product, the version does not show in the breadcrumbs:

![Screenshot 2023-11-03 at 7 11 36 AM](https://github.com/mulesoft/docs-site-ui/assets/10934908/95a7d91d-8210-43f8-ad5e-b15eb9a604a8)

This PR added the logic to make the version show. Here's a screenshot of my local build for validation:

![Screenshot 2023-11-03 at 7 13 23 AM](https://github.com/mulesoft/docs-site-ui/assets/10934908/4cbff916-172f-4b0e-963d-2e44af7f9974)

## JP Site

remove the "latest release" section from JP site since it doesn't have a release notes component. The "Trending Topics" section has the same look, just centered. Confirmed with Glenn that it is acceptable.

<img width="793" alt="Screenshot 2023-11-03 at 9 34 28 AM" src="https://github.com/mulesoft/docs-site-ui/assets/10934908/3c610016-5cee-4e20-95c3-e7bb7832f530">
