### PR TITLE
[W-14416061] add back latest releases to docs site

### DIFF
--- a/src/partials/landing-page/landing-page.hbs
+++ b/src/partials/landing-page/landing-page.hbs
@@ -9,6 +9,11 @@
   </div>
   {{else}}
   <div class='panels'>
+    {{#if preview}}
+      {{> contributor-signatures}}
+    {{else}}
+      {{> latest-releases}}
+    {{/if}}
     {{> trending-topics}}
   </div>
   {{/if}}

--- a/src/partials/landing-page/latest-releases.hbs
+++ b/src/partials/landing-page/latest-releases.hbs
@@ -11,9 +11,6 @@
         <col style="width: 90%;">
       </colgroup>
       <tbody>
-        {{#if preview}}
-        {{> quickstart}}
-        {{else}}
         {{#each (release-notes page.componentVersion.asciidoc.attributes.numberOfReleaseNotesItems)}}
         <tr>
           <td class="tableblock halign-left valign-top">
@@ -25,7 +22,6 @@
           </td>
         </tr>
         {{/each}}
-        {{/if}}
       </tbody>
     </table>
     <div class="paragraph">


### PR DESCRIPTION
ref: [W-14416061](https://gus.lightning.force.com/a07EE00001diY5cYAE)

In #587, the latest releases section was accidentally removed from the docs site. This PR brings it back