### PR TITLE
[W-10592972] add jp site search

### DIFF
--- a/src/js/vendor/coveo.bundle.js
+++ b/src/js/vendor/coveo.bundle.js
@@ -186,16 +186,24 @@ use ${osMap[this.clientOS].secondaryKeyLabelLong} + ${shortcutKeyMap.keyLabel}`
 
     updateInput () {
       if (this.searchboxInput) {
-        this.searchboxInput.placeholder = 'Search Docs'
-        // .getAttribute('aria-label') is used here instead of .ariaLabel
-        // because for some reason, it returned an error in firefox
-        this.searchboxInput.ariaLabel = this.searchboxInput
-          .getAttribute('aria-label')
-          .replace('Search field', 'Search Doc field')
-        if (this.searchboxDiv) {
-          if (!isMobileBrowser()) {
-            this.addKeyboardShortcutToSearchbox()
-            this.updateAriaLabelForInput()
+        if (document.documentElement.lang === 'en') {
+          this.searchboxInput.placeholder = 'Search Docs'
+          // .getAttribute('aria-label') is used here instead of .ariaLabel
+          // because for some reason, it returned an error in firefox
+          this.searchboxInput.ariaLabel = this.searchboxInput
+            .getAttribute('aria-label')
+            .replace('Search field', 'Search Doc field')
+          if (this.searchboxDiv) {
+            if (!isMobileBrowser()) {
+              this.addKeyboardShortcutToSearchbox()
+              this.updateAriaLabelForInput()
+            }
+          }
+        } else {
+          if (this.searchboxDiv) {
+            if (!isMobileBrowser()) {
+              this.addKeyboardShortcutToSearchbox()
+            }
           }
         }
         this.addLeftSearchIcon()

--- a/src/partials/head/head-meta.hbs
+++ b/src/partials/head/head-meta.hbs
@@ -12,15 +12,15 @@
     <meta name="keywords" content="{{page.keywords}}">
 {{/if}}
 
-{{#if (not (is-one-of (site-profile) 'jp' 'prod'))}}
+{{#if (not (is-one-of (site-profile) "jp" "prod"))}}
     <meta name="robots" content="none, noarchive">
 {{/if}}
 
 {{#if page.component}}
-    <meta name="product" content="{{page.component.title}}">
+    <meta name="product" content="{{#if (eq page.component.title "Home")}}Getting Started{{else}}{{page.component.title}}{{/if}}">
 {{/if}}
 
-{{#if (and page.version (not (is-one-of page.version 'default' 'latest' 'master' '~')))}}
+{{#if (and page.version (not (is-one-of page.version "default" "latest" "master" "~")))}}
     <meta name="version" content="{{or page.displayVersion page.version}}">
     {{#if (eq page.component.latest.version page.version)}}
         <meta name="is-latest-version" content="true">
@@ -48,7 +48,7 @@
     <meta name="version-with-latest" content="{{or page.displayVersion page.version}} [latest]">
 {{/if}}
 
-{{#if (is-one-of (site-profile) 'jp' 'prod')}}
+{{#if (is-one-of (site-profile) "jp" "prod")}}
     <meta name="description" content="MuleSoft Documentation Site">
 {{/if}}
 

--- a/src/partials/head/head-scripts.hbs
+++ b/src/partials/head/head-scripts.hbs
@@ -1,122 +1,17 @@
-{{#if (and env.GOOGLE_ANALYTICS_KEY (is-one-of (site-profile) 'jp' 'prod'))}}
-{{!--
-despite the Google analytics key label, the following script block is for segment rather than google analytics
-see https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/ for further info
---}}
-<script nonce="**CSP_NONCE**">
-  !function () {
-    var analytics = window.analytics = window.analytics || []; if (!analytics.initialize) if (analytics.invoked) window.console && console.error && console.error("Segment snippet included twice."); else {
-      analytics.invoked = !0; analytics.methods = ["trackSubmit", "trackClick", "trackLink", "trackForm", "pageview", "identify", "reset", "group", "track", "ready", "alias", "debug", "page", "once", "off", "on", "addSourceMiddleware", "addIntegrationMiddleware", "setAnonymousId", "addDestinationMiddleware"]; analytics.factory = function (e) { return function () { var t = Array.prototype.slice.call(arguments); t.unshift(e); analytics.push(t); return analytics } }; for (var e = 0; e < analytics.methods.length; e++) { var key = analytics.methods[e]; analytics[key] = analytics.factory(key) } analytics.load = function (key, e) { var t = document.createElement("script"); t.type = "text/javascript"; t.async = !0; t.src = "https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js"; var n = document.getElementsByTagName("script")[0]; n.parentNode.insertBefore(t, n); analytics._loadOptions = e }; analytics._writeKey = "{{env.GOOGLE_ANALYTICS_KEY}}";; analytics.SNIPPET_VERSION = "4.15.3";
-      analytics.load("{{env.GOOGLE_ANALYTICS_KEY}}");
-    }
-  }();
-</script>
-<!-- Google Tag Manager -->
-<script id="data-google-tag-manager" nonce="**CSP_NONCE**"
-  data-nonce="**CSP_NONCE**">(function (w, d, s, l, i) { w[l] = w[l] || []; w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' }); var f = d.getElementsByTagName(s)[0], j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl; var n = d.querySelector('[nonce]'); n && j.setAttribute('nonce', n.nonce || n.getAttribute('nonce')); f.parentNode.insertBefore(j, f); })(window, document, 'script', 'dataLayer', 'GTM-NH8DNZL');</script>
-<script nonce="**CSP_NONCE**" async="" src="https://www.googletagmanager.com/gtm.js?id=GTM-NH8DNZL"></script>
-<!-- End Google Tag Manager -->
+{{#if (and env.GOOGLE_ANALYTICS_KEY (not preview))}}
+  {{> segment-script }}
 {{/if}}
 
-<!-- Script for common areas on-clicks -->
-<script src="https://www.mulesoft.com/onClicks/app.js" defer=""></script>
-
-<!-- Start VWO Async SmartCode -->
-<script nonce="**CSP_NONCE**">
-  window._vwo_code = window._vwo_code || (function () {
-    var account_id = 582086,
-      settings_tolerance = 2000,
-      library_tolerance = 2500,
-      use_existing_jquery = false,
-      is_spa = 1,
-      hide_element = 'body',
-
-      /* DO NOT EDIT BELOW THIS LINE */
-      f = false, d = document, code = {
-        use_existing_jquery: function () { return use_existing_jquery; }, library_tolerance: function () { return library_tolerance; }, finish: function () { if (!f) { f = true; var a = d.getElementById('_vis_opt_path_hides'); if (a) a.parentNode.removeChild(a); } }, finished: function () { return f; }, load: function (a) { var b = d.createElement('script'); b.src = a; b.type = 'text/javascript'; b.innerText; b.onerror = function () { _vwo_code.finish(); }; d.getElementsByTagName('head')[0].appendChild(b); }, init: function () {
-          window.settings_timer = setTimeout(function () { _vwo_code.finish() }, settings_tolerance); var a = d.createElement('style'), b = hide_element ? hide_element + '{opacity:0 !important;filter:alpha(opacity=0) !important;background:none !important;}' : '', h = d.getElementsByTagName('head')[0]; a.setAttribute('id', '_vis_opt_path_hides'); a.setAttribute('type', 'text/css'); if (a.styleSheet) a.styleSheet.cssText = b; else a.appendChild(d.createTextNode(b)); h.appendChild(a); this.load('https://dev.visualwebsiteoptimizer.com/j.php?a=' + account_id + '&u=' + encodeURIComponent(d.URL) + '&f=' + (+is_spa) + '&r=' + Math.random()); return settings_timer;
-        }
-      }; window._vwo_settings_timer = code.init(); return code;
-  }());
-</script>
-<!-- End VWO Async SmartCode -->
-
-{{!-- Coveo --}}
-{{#if env.COVEO_API_KEY}}
-<script type="module" src="https://static.cloud.coveo.com/atomic/v2.46/atomic.esm.js"></script>
-<script type="text/javascript" src="https://static.cloud.coveo.com/coveo.analytics.js/2/coveoua.js"></script>
-<script nonce="**CSP_NONCE**">
-  (async () => {
-    async function initSearch (organizationId, accessToken) {
-      await customElements.whenDefined("atomic-search-interface");
-      const searchInterface = document.querySelector("#search");
-      const organizationEndpoints = await searchInterface.getOrganizationEndpoints(organizationId)
-      await searchInterface.initialize({
-        accessToken,
-        organizationId,
-        organizationEndpoints,
-      });
-      if (window.location.href.includes('/search')) searchInterface.executeFirstSearch();
-    }
-
-    async function initCoveoUserAnalytics (organizationId, accessToken) {
-      coveoua("init", accessToken, `https://${organizationId}.analytics.org.coveo.com`);
-      coveoua("send", "view", {
-        contentIdKey: '@clickableUri',
-        contentIdValue: window.location.href,
-        contentType: 'Docs',
-      });
-    }
-
-    const organizationId = "mulesoftprodqzggq6re";
-    const accessToken = "{{env.COVEO_API_KEY}}";
-
-    const isProdSite = (hostname) => hostname === "docs.mulesoft.com";
-
-    initSearch(organizationId, accessToken);
-    if (isProdSite(window.location.hostname)) initCoveoUserAnalytics(organizationId, accessToken);
-  })();
-</script>
+{{#if (or env.COVEO_API_KEY env.COVEO_API_KEY_JP)}}
+  {{> coveo-search-scripts org_id="mulesoftprodqzggq6re"}}
 {{/if}}
 
-<script nonce="**CSP_NONCE**">
-  (async () => {
-    async function initContentRecommendations (organizationId, accessToken) {
-      if (onHomePage(window.location.pathname)) {
-        await customElements.whenDefined('atomic-recs-interface');
-        const recommendInterface = document.querySelector('#recs');
-        const organizationEndpoints = await recommendInterface.getOrganizationEndpoints(organizationId);
-        await recommendInterface.initialize({
-          accessToken,
-          organizationId,
-          organizationEndpoints,
-        });
-        recommendInterface.getRecommendations();
-      }
-    }
+{{#if (eq (site-profile) 'prod')}}
+  {{> coveo-ua-script org_id="mulesoftprodqzggq6re"}}
+{{/if}}
 
-    const organizationId = "mulesoftprodqzggq6re";
-    const crToken = "xxb149e86e-a23c-43f6-9840-95d0bfa55830"; // no need to hide this token - it has extremely limited privilege and will show in the source code anyway
-
-    const onHomePage = (pathName) => pathName === '/' || pathName.endsWith('/general/');
-
-    initContentRecommendations(organizationId, crToken);
-  })();
-</script>
-
-{{!-- The two blocks scripts are needed for hypothesis apps to open in the review site --}}
 {{#if (eq (site-profile) 'review' )}}
-<script type="application/json" class="js-hypothesis-config">
-  {
-    "openSidebar": true,
-    "openLoginForm": true
-  }
-</script>
-
-<script type="application/json" class="js-hypothesis-config">
-  {
-    "sidebarAppUrl": "https://dev-docs-review-h.kdev.msap.io/app.html"
-  }
-</script>
-<script async defer src="https://dev-docs-review-h.kdev.msap.io/embed.js"></script>
+  {{> review-site-scripts }}
 {{/if}}
+
+{{> vwo-script }}

--- a/src/partials/head/head-scripts/coveo-search-scripts.hbs
+++ b/src/partials/head/head-scripts/coveo-search-scripts.hbs
@@ -1,0 +1,48 @@
+<script type="module" src="https://static.cloud.coveo.com/atomic/v2.48/atomic.esm.js"></script>
+<script nonce="**CSP_NONCE**">
+  (async () => {
+    async function initSearch (organizationId, accessToken) {
+      await customElements.whenDefined("atomic-search-interface");
+      const searchInterface = document.querySelector("#search");
+      if (searchInterface) {
+        const organizationEndpoints = await searchInterface.getOrganizationEndpoints(organizationId)
+        await searchInterface.initialize({
+          accessToken,
+          organizationId,
+          organizationEndpoints,
+        });
+        if (window.location.href.includes('/search')) searchInterface.executeFirstSearch();
+      }
+    }
+    
+    const organizationId = "{{ org_id }}";
+    const searchToken = "{{#if (eq (site-profile) 'jp')}}{{env.COVEO_API_KEY_JP}}{{else}}{{env.COVEO_API_KEY}}{{/if}}";
+
+    initSearch(organizationId, searchToken);
+  })();
+</script>
+
+<script nonce="**CSP_NONCE**">
+  (async () => {
+    async function initContentRecommendations (organizationId, accessToken) {
+      await customElements.whenDefined('atomic-recs-interface');
+      const recommendInterface = document.querySelector('#recs');
+      if (recommendInterface) {
+        const organizationEndpoints = await recommendInterface.getOrganizationEndpoints(organizationId);
+        await recommendInterface.initialize({
+          accessToken,
+          organizationId,
+          organizationEndpoints,
+        });
+        recommendInterface.getRecommendations();
+      }
+    }
+
+    const organizationId = "{{ org_id }}";
+    // no need to hide this token - it has extremely limited privilege and will show in the source code anyway
+    // TODO: store the CR token in Jenkins so it's easier to rotate if needed
+    const crToken = "xxb149e86e-a23c-43f6-9840-95d0bfa55830";
+
+    initContentRecommendations(organizationId, crToken);
+  })();
+</script>

--- a/src/partials/head/head-scripts/coveo-ua-script.hbs
+++ b/src/partials/head/head-scripts/coveo-ua-script.hbs
@@ -1,0 +1,20 @@
+<script type="text/javascript" src="https://static.cloud.coveo.com/coveo.analytics.js/2/coveoua.js"></script>
+<script nonce="**CSP_NONCE**">
+  (async () => {
+    async function initCoveoUserAnalytics (organizationId, accessToken) {
+      coveoua("init", accessToken, `https://${organizationId}.analytics.org.coveo.com`);
+      coveoua("send", "view", {
+        contentIdKey: '@clickableUri',
+        contentIdValue: window.location.href,
+        contentType: 'Docs',
+      });
+    }
+    
+    const organizationId = "{{ org_id }}";
+    const accessToken = "{{#if env.COVEO_API_KEY_JP}}{{env.COVEO_API_KEY_JP}}{{else}}{{env.COVEO_API_KEY}}{{/if}}";
+
+    const isProdSite = (hostname) => hostname === "docs.mulesoft.com";
+
+    if (isProdSite(window.location.hostname)) initCoveoUserAnalytics(organizationId, accessToken);
+  })();
+</script>

--- a/src/partials/head/head-scripts/gtm-scripts.hbs
+++ b/src/partials/head/head-scripts/gtm-scripts.hbs
@@ -1,0 +1,8 @@
+<!-- Google Tag Manager -->
+<script id="data-google-tag-manager" nonce="**CSP_NONCE**"
+  data-nonce="**CSP_NONCE**">(function (w, d, s, l, i) { w[l] = w[l] || []; w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' }); var f = d.getElementsByTagName(s)[0], j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl; var n = d.querySelector('[nonce]'); n && j.setAttribute('nonce', n.nonce || n.getAttribute('nonce')); f.parentNode.insertBefore(j, f); })(window, document, 'script', 'dataLayer', 'GTM-NH8DNZL');</script>
+<script nonce="**CSP_NONCE**" async="" src="https://www.googletagmanager.com/gtm.js?id=GTM-NH8DNZL"></script>
+<!-- End Google Tag Manager -->
+
+<!-- Script for common areas on-clicks -->
+<script src="https://www.mulesoft.com/onClicks/app.js" defer=""></script>

--- a/src/partials/head/head-scripts/review-site-script.hbs
+++ b/src/partials/head/head-scripts/review-site-script.hbs
@@ -1,0 +1,9 @@
+{{! The two blocks scripts need to be separated for hypothesis apps to open in the review site }}
+<script type="application/json" class="js-hypothesis-config">
+  { "openSidebar": true, "openLoginForm": true }
+</script>
+
+<script type="application/json" class="js-hypothesis-config">
+  { "sidebarAppUrl": "https://dev-docs-review-h.kdev.msap.io/app.html" }
+</script>
+<script async defer src="https://dev-docs-review-h.kdev.msap.io/embed.js"></script>

--- a/src/partials/head/head-scripts/segment-script.hbs
+++ b/src/partials/head/head-scripts/segment-script.hbs
@@ -1,0 +1,9 @@
+{{!-- https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/ --}}
+<script nonce="**CSP_NONCE**">
+  !function () {
+    var analytics = window.analytics = window.analytics || []; if (!analytics.initialize) if (analytics.invoked) window.console && console.error && console.error("Segment snippet included twice."); else {
+      analytics.invoked = !0; analytics.methods = ["trackSubmit", "trackClick", "trackLink", "trackForm", "pageview", "identify", "reset", "group", "track", "ready", "alias", "debug", "page", "once", "off", "on", "addSourceMiddleware", "addIntegrationMiddleware", "setAnonymousId", "addDestinationMiddleware"]; analytics.factory = function (e) { return function () { var t = Array.prototype.slice.call(arguments); t.unshift(e); analytics.push(t); return analytics } }; for (var e = 0; e < analytics.methods.length; e++) { var key = analytics.methods[e]; analytics[key] = analytics.factory(key) } analytics.load = function (key, e) { var t = document.createElement("script"); t.type = "text/javascript"; t.async = !0; t.src = "https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js"; var n = document.getElementsByTagName("script")[0]; n.parentNode.insertBefore(t, n); analytics._loadOptions = e }; analytics._writeKey = "{{env.GOOGLE_ANALYTICS_KEY}}";; analytics.SNIPPET_VERSION = "4.15.3";
+      analytics.load("{{env.GOOGLE_ANALYTICS_KEY}}");
+    }
+  }();
+</script>

--- a/src/partials/head/head-scripts/vwo-script.hbs
+++ b/src/partials/head/head-scripts/vwo-script.hbs
@@ -1,0 +1,17 @@
+<script nonce="**CSP_NONCE**">
+  window._vwo_code = window._vwo_code || (function () {
+    var account_id = 582086,
+      settings_tolerance = 2000,
+      library_tolerance = 2500,
+      use_existing_jquery = false,
+      is_spa = 1,
+      hide_element = 'body',
+
+      /* DO NOT EDIT BELOW THIS LINE */
+      f = false, d = document, code = {
+        use_existing_jquery: function () { return use_existing_jquery; }, library_tolerance: function () { return library_tolerance; }, finish: function () { if (!f) { f = true; var a = d.getElementById('_vis_opt_path_hides'); if (a) a.parentNode.removeChild(a); } }, finished: function () { return f; }, load: function (a) { var b = d.createElement('script'); b.src = a; b.type = 'text/javascript'; b.innerText; b.onerror = function () { _vwo_code.finish(); }; d.getElementsByTagName('head')[0].appendChild(b); }, init: function () {
+          window.settings_timer = setTimeout(function () { _vwo_code.finish() }, settings_tolerance); var a = d.createElement('style'), b = hide_element ? hide_element + '{opacity:0 !important;filter:alpha(opacity=0) !important;background:none !important;}' : '', h = d.getElementsByTagName('head')[0]; a.setAttribute('id', '_vis_opt_path_hides'); a.setAttribute('type', 'text/css'); if (a.styleSheet) a.styleSheet.cssText = b; else a.appendChild(d.createTextNode(b)); h.appendChild(a); this.load('https://dev.visualwebsiteoptimizer.com/j.php?a=' + account_id + '&u=' + encodeURIComponent(d.URL) + '&f=' + (+is_spa) + '&r=' + Math.random()); return settings_timer;
+        }
+      }; window._vwo_settings_timer = code.init(); return code;
+  }());
+</script>

--- a/src/partials/nav.hbs
+++ b/src/partials/nav.hbs
@@ -1,8 +1,8 @@
 <nav class="nav fit" aria-label="Docs">
   <span class="mobile-nav-focus-trapper"></span>
-  {{#if (and env.COVEO_API_KEY (not (is-one-of (site-profile) 'archive' 'jp')))}}
+  {{#if (or preview (is-one-of (site-profile) 'prod' 'jp'))}}
   <div class="search">
-    <atomic-search-interface id="search" search-hub="Documentation">
+    <atomic-search-interface id="search" localization-compatibility-version="v4" {{#if (eq (site-profile) 'jp' )}}search-hub="Documentation-jp" language="ja"{{else}}search-hub="Documentation"{{/if}}>
       <atomic-search-layout>
           <atomic-layout-section section="search">
               <atomic-search-box redirection-url="{{relativize site.url}}/general/search{{#if preview}}.html{{/if}}">

--- a/src/partials/search/search-interface.hbs
+++ b/src/partials/search/search-interface.hbs
@@ -15,7 +15,7 @@
           <atomic-query-summary></atomic-query-summary>
           <atomic-refine-toggle></atomic-refine-toggle>
           <atomic-sort-dropdown>
-            <atomic-sort-expression label="Relevance" expression="relevancy"></atomic-sort-expression>
+            <atomic-sort-expression label="{{#if (eq (site-profile) 'jp')}}関連性{{else}}Relevance{{/if}}" expression="relevancy"></atomic-sort-expression>
             <atomic-sort-expression label="Version (Descending)"
               expression="mulesoftversionmajor descending, mulesoftversionminor descending, mulesoftversionpatch descending"></atomic-sort-expression>
           </atomic-sort-dropdown>

--- a/src/partials/search/search-interface.hbs
+++ b/src/partials/search/search-interface.hbs
@@ -1,9 +1,9 @@
-{{#if env.COVEO_API_KEY}}
+{{#if (or env.COVEO_API_KEY env.COVEO_API_JP)}}
 <div class="search-div">
   <atomic-aria-live></atomic-aria-live>
-  <atomic-search-interface id="search"
+  <atomic-search-interface id="search" localization-compatibility-version="v4"
     fields-to-include='["mulesoftislatestversion", "mulesoftproductversion", "mulesoftversionmajor", "mulesoftversionminor", "mulesoftversionpatch", "mulesoftversionwithlatest", "product", "version"]'
-    search-hub="Documentation">
+    {{#if (eq (site-profile) 'jp' )}}search-hub="Documentation-jp" language="ja"{{else}}search-hub="Documentation"{{/if}}>
     <atomic-search-layout>
       <atomic-layout-section section="facets">
       <atomic-facet facet-id="product" field="product" heading-level=1 label="Filter by Product"></atomic-facet>

--- a/src/partials/search/search-result-template.hbs
+++ b/src/partials/search/search-result-template.hbs
@@ -53,7 +53,7 @@
           <atomic-result-text field="version"></atomic-result-text>
         </atomic-field-condition>
         <atomic-field-condition class="field" if-defined="mulesoftislatestversion">
-          <atomic-result-badge label="latest version"></atomic-result-badge>
+          <atomic-result-badge label="{{#if (eq (site-profile) 'jp')}}最新{{else}}latest version{{/if}}"></atomic-result-badge>
         </atomic-field-condition>
       </atomic-result-fields-list>
     </atomic-result-section-bottom-metadata>

--- a/src/partials/toolbar/toolbar.hbs
+++ b/src/partials/toolbar/toolbar.hbs
@@ -10,7 +10,7 @@
       <img loading="lazy" src="{{@root.uiRootPath}}/img/icons/arrow-down.svg" alt="">
     </button>
     {{/if}}
-    {{#if (and env.COVEO_API_KEY (ne page.title 'Search Docs') (not (is-one-of (site-profile) 'archive' 'jp')))}}
+    {{#if (and (or env.COVEO_API_KEY env.COVEO_API_KEY_JP) (ne page.title 'Search Docs') (ne (site-profile) 'archive'))}}
     <button aria-label="Search Docs" class="button toolbar-search-button">
       <img loading="lazy" class="toolbar-search-button-icon" src="{{@root.uiRootPath}}/img/icons/search.svg"
         alt="Search Docs">


### PR DESCRIPTION
ref: W-10592972

add JP site search. Some texts need to be localized later.

![Screenshot 2023-11-07 at 4 20 08 PM](https://github.com/mulesoft/docs-site-ui/assets/10934908/e5e8612b-d921-4f45-a3ac-ddb40b0da2a4)

Also contains the following enhancements:
- break up head-scripts.hbs into multiple scripts, making it easier to see and manage
- change pages within the component "Home" to have "Getting Started" as the value of the metadata "product"
- upgrade atomic version