### PR TITLE
[W-14470174] Incorporate feedback from design for feedback form

### DIFF
--- a/src/css/adoc/doc-footer.css
+++ b/src/css/adoc/doc-footer.css
@@ -2,20 +2,12 @@
   padding: 300px var(--xl) var(--xl);
 
   & button {
-    border-color: var(--sds-c-button-color-background);
-    border-radius: 5px;
     border-width: 2px;
-    color: var(--sds-c-button-color-background);
     column-gap: 4px;
     font-size: 14px;
     font-weight: var(--weight-bold);
     height: 28px;
     padding: 4px 12px;
-
-    &:hover:not(:disabled) {
-      /* this is for overriding the default button focus color */
-      color: var(--sds-c-button-color-background);
-    }
 
     & img {
       height: 100%;
@@ -41,8 +33,19 @@
   border-bottom: 1px solid var(--lume-g-color-neutral-80);
   border-radius: 2px;
   border-top: 1px solid var(--lume-g-color-neutral-80);
+  font-family: var(--font-sans-serif);
+  font-size: 14px;
   min-width: 340px;
   width: 90%;
+
+  & .feedback-title,
+  & legend {
+    font-weight: var(--weight-bold);
+  }
+
+  & .feedback-upper {
+    text-transform: uppercase;
+  }
 
   & .feedback-ack {
     align-items: center;
@@ -90,16 +93,8 @@
     padding-top: 5px;
 
     & .feedback-form-button {
-      background-color: var(--sds-c-button-color-background);
-      border-radius: 5px;
-      font-family: var(--font-sans-serif);
-      font-size: 14px;
       line-height: unset;
       margin-bottom: 1em;
-
-      &:hover {
-        background-color: var(--sds-c-button-color-background-hover);
-      }
     }
   }
 
@@ -125,8 +120,6 @@
   & .feedback-form-thank-you {
     color: var(--lume-g-color-green-50);
     display: flex;
-    font-size: 14px;
-    font-weight: var(--weight-bold);
     justify-content: center;
     padding-bottom: var(--md);
     width: 75%;
@@ -138,8 +131,6 @@
 
   & .validation-text {
     color: var(--lume-g-color-red-50);
-    font-family: var(--font-sans-serif);
-    font-size: 12px;
     position: relative;
     top: -8px;
 
@@ -150,7 +141,6 @@
 
   & fieldset {
     & label {
-      font-family: var(--font-sans-serif);
       padding-left: 0.5em;
       vertical-align: text-bottom;
     }
@@ -159,8 +149,6 @@
   & fieldset,
   & span:not([aria-live], .validation-text, .feedback-form-thank-you) {
     border: none;
-    font-size: 12px;
-    font-weight: var(--weight-bold);
     margin: auto;
     padding: 0 0 1em;
     width: 100%;
@@ -168,9 +156,9 @@
 
   & input:not([type="button"], [type="checkbox"], [type="submit"]),
   & textarea {
-    border: 1px solid var(--steel-2);
-    border-radius: 4px;
-    margin-bottom: 8px;
+    border: 1px solid var(--lume-g-color-neutral-80);
+    border-radius: var(--radius);
+    margin: 3px 0 8px;
     min-height: 32px;
     padding: 8px;
     width: 100%;
@@ -181,24 +169,16 @@
 
     &::placeholder {
       color: var(--lume-g-color-neutral-50);
-      font-size: 12px;
     }
   }
 
   & legend,
   & p > label {
-    font-size: 14px;
-    margin-bottom: 8px;
+    margin-bottom: 3px;
   }
 
   & p {
-    font-size: var(--font-size-default);
-    font-weight: var(--weight-bold);
     margin: auto;
-  }
-
-  & #feedback-question-subtitle {
-    font-family: var(--font-sans-serif);
   }
 
   &:has(> .feedback-form.hide):has(> .feedback-second-row.hide):has(
@@ -246,11 +226,6 @@
         margin-left: -25px;
         margin-top: -72px;
       }
-    }
-
-    & legend,
-    & p {
-      font-size: 14px;
     }
   }
 }

--- a/src/locales/feedback-questions.json
+++ b/src/locales/feedback-questions.json
@@ -1,14 +1,14 @@
 {
   "v1": {
     "yes": {
-      "legend": "Thanks for the feedback! What made this article helpful? (Please check at least 1 checkbox.)",
+      "legend": "Thanks for the feedback! What made this article helpful?",
       "is_accurate": "Contains accurate information",
       "is_comprehensive": "Includes all of the information I need",
       "is_clear": "Easy to understand with clear explanations and visuals",
       "other": "Something else"
     },
     "no": {
-      "legend": "We're sorry to hear that. How can we improve this article? (Please check at least 1 checkbox.)",
+      "legend": "We're sorry to hear that. How can we improve this article?",
       "is_accurate": "Contains inaccurate or outdated information",
       "is_comprehensive": "Missing important information",
       "is_clear": "Confusing or difficult to understand",

--- a/src/partials/feedback-form/feedback-form.hbs
+++ b/src/partials/feedback-form/feedback-form.hbs
@@ -2,7 +2,7 @@
   <section class="feedback-section flex align-center col">
     <div class="feedback-row feedback-first-row flex align-center">
       <div>
-        <p id="feedback-question" class="feedback-title feedback-upper">Did you find this article useful?</p>
+        <p id="feedback-question" class="feedback-title feedback-upper">Did this article solve your issue?</p>
         <p id="feedback-question-subtitle">Let us know so we can improve!</p>
       </div>
       <div class="feedback-options flex">

--- a/src/partials/feedback-form/feedback-form.hbs
+++ b/src/partials/feedback-form/feedback-form.hbs
@@ -2,7 +2,7 @@
   <section class="feedback-section flex align-center col">
     <div class="feedback-row feedback-first-row flex align-center">
       <div>
-        <p id="feedback-question">Did you find this article useful?</p>
+        <p id="feedback-question" class="feedback-title feedback-upper">Did you find this article useful?</p>
         <p id="feedback-question-subtitle">Let us know so we can improve!</p>
       </div>
       <div class="feedback-options flex">
@@ -23,7 +23,7 @@
       </div>
     </div>
     {{> written-feedback-section }}
-    <span class="feedback-form-thank-you hide" tabIndex="-1">
+    <span class="feedback-form-thank-you feedback-title hide" tabIndex="-1">
       <img loading="lazy" src="{{@root.uiRootPath}}/img/icons/success.svg" alt="">
       Your feedback has been successfully submitted. Thank you!
     </span>

--- a/src/partials/feedback-form/written-feedback-section.hbs
+++ b/src/partials/feedback-form/written-feedback-section.hbs
@@ -4,7 +4,7 @@
             checkbox.</span>
         <fieldset></fieldset>
         <p>
-            <label for="comment">Would you like to share any additional feedback? (Optional)</label>
+            <label for="comment" class="feedback-title">Would you like to share any additional feedback? (Optional)</label>
             <textarea maxlength="1000" placeholder="Tell us what you liked or didn’t like." type="text" id="comment"
                 name="comment" rows="4"></textarea>
         </p>


### PR DESCRIPTION
This PR makes (mostly subtle) changes to our feedback form styling based on comments from design, including:

* Change font size for all text to 16px.
* Remove bold from normal text--only titles should be in bold.
* Make minor changes to spacing to make text easier to scan.
* Update text to align with proposal from design.

As a nice to have, I streamlined some of the button css. In the wake of the One Salesforce reskin, we can now inherit these css values directly from the main `button.css` styles.

Here's a comparison:

**Old**

![Screenshot 2023-11-13 at 12 44 13 PM](https://github.com/mulesoft/docs-site-ui/assets/5760201/ed81d86a-c94f-4249-aa8c-2e7589ac8598)

**New**

![Screenshot 2023-11-13 at 2 50 06 PM](https://github.com/mulesoft/docs-site-ui/assets/5760201/07e7cefb-adb6-4c14-b6c8-d57f8249b766)

