### PR TITLE
[W-14482220] Localize missing search page strings

### DIFF
--- a/src/js/vendor/coveo.bundle.js
+++ b/src/js/vendor/coveo.bundle.js
@@ -92,14 +92,6 @@ use ${osMap[this.clientOS].secondaryKeyLabelLong} + ${shortcutKeyMap.keyLabel}`
       }
     }
 
-    addSubmitButtonText () {
-      const submitText = document.createElement('p')
-      submitText.style.display = this.searchboxInput.value ? 'inherit' : 'none'
-      submitText.style.margin = this.searchboxInput.value ? 'auto 10px auto -5px' : 'auto 10px auto 0'
-      submitText.innerHTML = 'Docs'
-      this.searchboxSubmitButton.appendChild(submitText)
-    }
-
     appendKeyboardShortcut () {
       if (this.searchboxInput) {
         this.searchboxInput.placeholder = `${this.searchboxInput.placeholder} (${
@@ -214,7 +206,6 @@ use ${osMap[this.clientOS].secondaryKeyLabelLong} + ${shortcutKeyMap.keyLabel}`
     updateSubmitButton () {
       if (this.searchboxSubmitButton) {
         this.searchboxSubmitButton.setAttribute('aria-label', 'Search Docs')
-        this.addSubmitButtonText()
       }
     }
   }

--- a/src/locales/messages.json
+++ b/src/locales/messages.json
@@ -19,7 +19,9 @@
       "mobile-table-hide": "Hide",
       "right-nav-on-this-page": "On this page:",
       "right-nav-skip-to-main": "Skip to main content",
-      "right-nav-skip-to-sections": "Skip to page content sections"
+      "right-nav-skip-to-sections": "Skip to page content sections",
+      "search-close-button": "Close",
+      "search-toolbar-button": "Search Docs"
       },
     "jp": {
       "breadcrumbs-home": "ホームページ",
@@ -39,6 +41,8 @@
       "mobile-table-toggle": "クリックしてテーブルを切り替え",
       "mobile-table-show": "表示",
       "mobile-table-hide": "非表示",
-      "right-nav-on-this-page": "このページの内容:"
+      "right-nav-on-this-page": "このページの内容:",
+      "search-close-button": "閉じる",
+      "search-toolbar-button": "ドキュメントの検索"
     }
 }

--- a/src/partials/search/search-interface.hbs
+++ b/src/partials/search/search-interface.hbs
@@ -6,7 +6,7 @@
     {{#if (eq (site-profile) 'jp' )}}search-hub="Documentation-jp" language="ja"{{else}}search-hub="Documentation"{{/if}}>
     <atomic-search-layout>
       <atomic-layout-section section="facets">
-      <atomic-facet facet-id="product" field="product" heading-level=1 label="Filter by Product"></atomic-facet>
+      <atomic-facet facet-id="product" field="product" heading-level=1 label="{{#if (eq (site-profile) 'jp')}}製品別に絞り込み{{else}}Filter by Product{{/if}}"></atomic-facet>
       <atomic-facet-manager></atomic-facet-manager>
       </atomic-layout-section>
       <atomic-layout-section section="main">
@@ -16,7 +16,7 @@
           <atomic-refine-toggle></atomic-refine-toggle>
           <atomic-sort-dropdown>
             <atomic-sort-expression label="{{#if (eq (site-profile) 'jp')}}関連性{{else}}Relevance{{/if}}" expression="relevancy"></atomic-sort-expression>
-            <atomic-sort-expression label="Version (Descending)"
+            <atomic-sort-expression label="{{#if (eq (site-profile) 'jp')}}バージョン (降順){{else}}Version (Descending){{/if}}"
               expression="mulesoftversionmajor descending, mulesoftversionminor descending, mulesoftversionpatch descending"></atomic-sort-expression>
           </atomic-sort-dropdown>
           <atomic-did-you-mean></atomic-did-you-mean>

--- a/src/partials/toolbar/search-toolbar.hbs
+++ b/src/partials/toolbar/search-toolbar.hbs
@@ -1,6 +1,7 @@
 <nav aria-label="Docs Search toolbar" class="toolbar search-toolbar">
   <button class="button search-page-back-button">
-    <img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""> Close
+    <img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt="">
+    <span data-l10n-text="search-close-button"></span>
   </button>
   <atomic-external>
     <atomic-layout-section section="search">

--- a/src/partials/toolbar/toolbar.hbs
+++ b/src/partials/toolbar/toolbar.hbs
@@ -11,9 +11,9 @@
     </button>
     {{/if}}
     {{#if (and (or env.COVEO_API_KEY env.COVEO_API_KEY_JP) (ne page.title 'Search Docs') (ne (site-profile) 'archive'))}}
-    <button aria-label="Search Docs" class="button toolbar-search-button">
+    <button data-l10n-label="search-toolbar-button" class="button toolbar-search-button">
       <img loading="lazy" class="toolbar-search-button-icon" src="{{@root.uiRootPath}}/img/icons/search.svg"
-        alt="Search Docs">
+        data-l10n-alt="search-toolbar-button">
     </button>
     {{/if}}
   </div>


### PR DESCRIPTION
Localize missing strings on search page. A couple of notes:

* The Coveo code does not interoperate well with our localization functionality. This is because their code uses web components and shadow dom, which by their nature, are isolated from the rest of the document. (You can't use `document.querySelector` without passing information about the containing component.) This means that in some places we're still using the old handlebars conditionals instead of our l10n code.
* I removed the "Docs" text from the search button as seen below. This button is shared on the results page and when you're typing, which means that if you put in the Japanese text, it's really squeezed for room. (Docs also doesn't translate well on its own--and Search Docs which we're using elsewhere is too long.)

![Screenshot 2023-11-27 at 8 48 05 AM](https://github.com/mulesoft/docs-site-ui/assets/5760201/a9038114-8186-42e2-a9b1-26d1326f60f8)
