### PR TITLE
[W-14653224] make all external links open in new window

### DIFF
--- a/preview-site-src/elements/admonition.adoc
+++ b/preview-site-src/elements/admonition.adoc
@@ -3,7 +3,7 @@
 :page-component-name: elements
 :page-notice-banner-message: This is a <b>custom</b> notice message with a <a href="https://salesforce.com" target="_blank" rel="noopener">link</a>.
 
-https://docs.antora.org/antora/latest/asciidoc/admonitions/[antora docs reference]
+https://docs.antora.org/antora/latest/asciidoc/admonitions/[Antora Docs Reference]
 
 NOTE: If you go into the basement, see if you can find Kenny's parka.
 

--- a/preview-site-src/elements/admonition.adoc
+++ b/preview-site-src/elements/admonition.adoc
@@ -3,7 +3,7 @@
 :page-component-name: elements
 :page-notice-banner-message: This is a <b>custom</b> notice message with a <a href="https://salesforce.com" target="_blank" rel="noopener">link</a>.
 
-https://docs.antora.org/antora/latest/asciidoc/admonitions/[Antora Docs Reference]
+https://docs.antora.org/antora/latest/asciidoc/admonitions/[Antora docs reference]
 
 NOTE: If you go into the basement, see if you can find Kenny's parka.
 

--- a/preview-site-src/elements/admonition.adoc
+++ b/preview-site-src/elements/admonition.adoc
@@ -3,7 +3,7 @@
 :page-component-name: elements
 :page-notice-banner-message: This is a <b>custom</b> notice message with a <a href="https://salesforce.com" target="_blank" rel="noopener">link</a>.
 
-https://docs.antora.org/antora/latest/asciidoc/admonitions/[Antora docs reference^]
+https://docs.antora.org/antora/latest/asciidoc/admonitions/[antora docs reference]
 
 NOTE: If you go into the basement, see if you can find Kenny's parka.
 

--- a/preview-site-src/elements/code-block.adoc
+++ b/preview-site-src/elements/code-block.adoc
@@ -3,7 +3,7 @@
 :page-component-name: elements
 :page-notice-banner-message: This is a custom notice message about code blocks
 
-https://docs.antora.org/antora/latest/asciidoc/source/[Antora Docs Reference]
+https://docs.antora.org/antora/latest/asciidoc/source/[Antora docs reference]
 
 The following are code blocks of different languages (they are highlighted differently).
 

--- a/preview-site-src/elements/code-block.adoc
+++ b/preview-site-src/elements/code-block.adoc
@@ -3,7 +3,7 @@
 :page-component-name: elements
 :page-notice-banner-message: This is a custom notice message about code blocks
 
-https://docs.antora.org/antora/latest/asciidoc/source/[Antora docs reference^]
+https://docs.antora.org/antora/latest/asciidoc/source/[antora docs reference]
 
 The following are code blocks of different languages (they are highlighted differently).
 

--- a/preview-site-src/elements/code-block.adoc
+++ b/preview-site-src/elements/code-block.adoc
@@ -3,7 +3,7 @@
 :page-component-name: elements
 :page-notice-banner-message: This is a custom notice message about code blocks
 
-https://docs.antora.org/antora/latest/asciidoc/source/[antora docs reference]
+https://docs.antora.org/antora/latest/asciidoc/source/[Antora Docs Reference]
 
 The following are code blocks of different languages (they are highlighted differently).
 

--- a/preview-site-src/elements/embedded-media.adoc
+++ b/preview-site-src/elements/embedded-media.adoc
@@ -5,7 +5,7 @@
 
 == Image
 
-https://docs.antora.org/antora/latest/page/image-resource-id-examples/[Antora docs reference^]
+https://docs.antora.org/antora/latest/page/image-resource-id-examples/[antora docs reference]
 
 Here's an inline image: image:images/devkitoverviewarchitecture.png["alt text", height=30px], do you see it?
 
@@ -16,7 +16,7 @@ image::images/devkitoverviewarchitecture.png[alt text]
 
 == Video
 
-https://docs.antora.org/antora/latest/asciidoc/embed-video/[Antora docs reference^]
+https://docs.antora.org/antora/latest/asciidoc/embed-video/[antora docs reference]
 
 video::rPQoq7ThGAU[youtube]
 

--- a/preview-site-src/elements/embedded-media.adoc
+++ b/preview-site-src/elements/embedded-media.adoc
@@ -5,7 +5,7 @@
 
 == Image
 
-https://docs.antora.org/antora/latest/page/image-resource-id-examples/[Antora Docs Reference]
+https://docs.antora.org/antora/latest/page/image-resource-id-examples/[Antora docs reference]
 
 Here's an inline image: image:images/devkitoverviewarchitecture.png["alt text", height=30px], do you see it?
 
@@ -16,7 +16,7 @@ image::images/devkitoverviewarchitecture.png[alt text]
 
 == Video
 
-https://docs.antora.org/antora/latest/asciidoc/embed-video/[Antora Docs Reference]
+https://docs.antora.org/antora/latest/asciidoc/embed-video/[Antora docs reference]
 
 video::rPQoq7ThGAU[youtube]
 

--- a/preview-site-src/elements/embedded-media.adoc
+++ b/preview-site-src/elements/embedded-media.adoc
@@ -5,7 +5,7 @@
 
 == Image
 
-https://docs.antora.org/antora/latest/page/image-resource-id-examples/[antora docs reference]
+https://docs.antora.org/antora/latest/page/image-resource-id-examples/[Antora Docs Reference]
 
 Here's an inline image: image:images/devkitoverviewarchitecture.png["alt text", height=30px], do you see it?
 
@@ -16,7 +16,7 @@ image::images/devkitoverviewarchitecture.png[alt text]
 
 == Video
 
-https://docs.antora.org/antora/latest/asciidoc/embed-video/[antora docs reference]
+https://docs.antora.org/antora/latest/asciidoc/embed-video/[Antora Docs Reference]
 
 video::rPQoq7ThGAU[youtube]
 

--- a/preview-site-src/elements/list.adoc
+++ b/preview-site-src/elements/list.adoc
@@ -3,7 +3,7 @@
 :page-component-name: elements
 :page-notice-banner-message: This is a custom notice message about lists
 
-https://docs.antora.org/antora/latest/asciidoc/lists/[Antora Docs Reference]
+https://docs.antora.org/antora/latest/asciidoc/lists/[Antora docs reference]
 
 == Ordered lists
 

--- a/preview-site-src/elements/list.adoc
+++ b/preview-site-src/elements/list.adoc
@@ -3,7 +3,7 @@
 :page-component-name: elements
 :page-notice-banner-message: This is a custom notice message about lists
 
-https://docs.antora.org/antora/latest/asciidoc/lists/[Antora docs reference^]
+https://docs.antora.org/antora/latest/asciidoc/lists/[antora docs reference]
 
 == Ordered lists
 

--- a/preview-site-src/elements/list.adoc
+++ b/preview-site-src/elements/list.adoc
@@ -3,7 +3,7 @@
 :page-component-name: elements
 :page-notice-banner-message: This is a custom notice message about lists
 
-https://docs.antora.org/antora/latest/asciidoc/lists/[antora docs reference]
+https://docs.antora.org/antora/latest/asciidoc/lists/[Antora Docs Reference]
 
 == Ordered lists
 

--- a/preview-site-src/elements/miscellaneous.adoc
+++ b/preview-site-src/elements/miscellaneous.adoc
@@ -6,19 +6,19 @@
 == Text
 
 [#bold]
-This is *bold*. This is _italic_. This is *_bold and italic_*. (https://docs.antora.org/antora/latest/asciidoc/bold/[antora docs reference])
+This is *bold*. This is _italic_. This is *_bold and italic_*. (https://docs.antora.org/antora/latest/asciidoc/bold/[Antora Docs Reference])
 
-This is a new paragraph for a monospace `word`, and a monospace `phrase of text`. `*_monospace bold italic phrase_*` & ``**__char__**``actor``**__s__**`` (https://docs.antora.org/antora/latest/asciidoc/monospace/[antora docs reference])
+This is a new paragraph for a monospace `word`, and a monospace `phrase of text`. `*_monospace bold italic phrase_*` & ``**__char__**``actor``**__s__**`` (https://docs.antora.org/antora/latest/asciidoc/monospace/[Antora Docs Reference])
 
-Let's #highlight this phrase# and the i and s in th##is##. (https://docs.antora.org/antora/latest/asciidoc/highlight/[antora docs reference])
+Let's #highlight this phrase# and the i and s in th##is##. (https://docs.antora.org/antora/latest/asciidoc/highlight/[Antora Docs Reference])
 
-&#169; &#8656; &#8592; &#174; (https://docs.antora.org/antora/latest/asciidoc/special-characters-and-symbols/[antora docs reference])
+&#169; &#8656; &#8592; &#174; (https://docs.antora.org/antora/latest/asciidoc/special-characters-and-symbols/[Antora Docs Reference])
 
-The chemical formula for water is H~2~O. What is the answer to E=mc^2^? (https://docs.antora.org/antora/latest/asciidoc/subscript-and-superscript/[antora docs reference])
+The chemical formula for water is H~2~O. What is the answer to E=mc^2^? (https://docs.antora.org/antora/latest/asciidoc/subscript-and-superscript/[Antora Docs Reference])
 
 == URL
 
-https://docs.antora.org/antora/latest/asciidoc/external-urls/[antora docs reference]
+https://docs.antora.org/antora/latest/asciidoc/external-urls/[Antora Docs Reference]
 
 Looking for help?
 Visit the https://antora.zulipchat.com[Antora chat room].
@@ -27,7 +27,7 @@ This is the https://antora.zulipchat.com[external link^] for the same URL.
 
 == Xref
 
-https://docs.antora.org/antora/latest/asciidoc/in-page-xref/[antora docs reference]
+https://docs.antora.org/antora/latest/asciidoc/in-page-xref/[Antora Docs Reference]
 
 This is an in-page cross reference for the previous Text section: <<_text>>.
 

--- a/preview-site-src/elements/miscellaneous.adoc
+++ b/preview-site-src/elements/miscellaneous.adoc
@@ -6,19 +6,19 @@
 == Text
 
 [#bold]
-This is *bold*. This is _italic_. This is *_bold and italic_*. (https://docs.antora.org/antora/latest/asciidoc/bold/[Antora Docs Reference])
+This is *bold*. This is _italic_. This is *_bold and italic_*. (https://docs.antora.org/antora/latest/asciidoc/bold/[Antora docs reference])
 
-This is a new paragraph for a monospace `word`, and a monospace `phrase of text`. `*_monospace bold italic phrase_*` & ``**__char__**``actor``**__s__**`` (https://docs.antora.org/antora/latest/asciidoc/monospace/[Antora Docs Reference])
+This is a new paragraph for a monospace `word`, and a monospace `phrase of text`. `*_monospace bold italic phrase_*` & ``**__char__**``actor``**__s__**`` (https://docs.antora.org/antora/latest/asciidoc/monospace/[Antora docs reference])
 
-Let's #highlight this phrase# and the i and s in th##is##. (https://docs.antora.org/antora/latest/asciidoc/highlight/[Antora Docs Reference])
+Let's #highlight this phrase# and the i and s in th##is##. (https://docs.antora.org/antora/latest/asciidoc/highlight/[Antora docs reference])
 
-&#169; &#8656; &#8592; &#174; (https://docs.antora.org/antora/latest/asciidoc/special-characters-and-symbols/[Antora Docs Reference])
+&#169; &#8656; &#8592; &#174; (https://docs.antora.org/antora/latest/asciidoc/special-characters-and-symbols/[Antora docs reference])
 
-The chemical formula for water is H~2~O. What is the answer to E=mc^2^? (https://docs.antora.org/antora/latest/asciidoc/subscript-and-superscript/[Antora Docs Reference])
+The chemical formula for water is H~2~O. What is the answer to E=mc^2^? (https://docs.antora.org/antora/latest/asciidoc/subscript-and-superscript/[Antora docs reference])
 
 == URL
 
-https://docs.antora.org/antora/latest/asciidoc/external-urls/[Antora Docs Reference]
+https://docs.antora.org/antora/latest/asciidoc/external-urls/[Antora docs reference]
 
 Looking for help?
 Visit the https://antora.zulipchat.com[Antora chat room].
@@ -27,7 +27,7 @@ This is the https://antora.zulipchat.com[external link^] for the same URL.
 
 == Xref
 
-https://docs.antora.org/antora/latest/asciidoc/in-page-xref/[Antora Docs Reference]
+https://docs.antora.org/antora/latest/asciidoc/in-page-xref/[Antora docs reference]
 
 This is an in-page cross reference for the previous Text section: <<_text>>.
 

--- a/preview-site-src/elements/miscellaneous.adoc
+++ b/preview-site-src/elements/miscellaneous.adoc
@@ -6,19 +6,19 @@
 == Text
 
 [#bold]
-This is *bold*. This is _italic_. This is *_bold and italic_*. (https://docs.antora.org/antora/latest/asciidoc/bold/[Antora docs reference^])
+This is *bold*. This is _italic_. This is *_bold and italic_*. (https://docs.antora.org/antora/latest/asciidoc/bold/[antora docs reference])
 
-This is a new paragraph for a monospace `word`, and a monospace `phrase of text`. `*_monospace bold italic phrase_*` & ``**__char__**``actor``**__s__**`` (https://docs.antora.org/antora/latest/asciidoc/monospace/[Antora docs reference^])
+This is a new paragraph for a monospace `word`, and a monospace `phrase of text`. `*_monospace bold italic phrase_*` & ``**__char__**``actor``**__s__**`` (https://docs.antora.org/antora/latest/asciidoc/monospace/[antora docs reference])
 
-Let's #highlight this phrase# and the i and s in th##is##. (https://docs.antora.org/antora/latest/asciidoc/highlight/[Antora docs reference^])
+Let's #highlight this phrase# and the i and s in th##is##. (https://docs.antora.org/antora/latest/asciidoc/highlight/[antora docs reference])
 
-&#169; &#8656; &#8592; &#174; (https://docs.antora.org/antora/latest/asciidoc/special-characters-and-symbols/[Antora docs reference^])
+&#169; &#8656; &#8592; &#174; (https://docs.antora.org/antora/latest/asciidoc/special-characters-and-symbols/[antora docs reference])
 
-The chemical formula for water is H~2~O. What is the answer to E=mc^2^? (https://docs.antora.org/antora/latest/asciidoc/subscript-and-superscript/[Antora docs reference^])
+The chemical formula for water is H~2~O. What is the answer to E=mc^2^? (https://docs.antora.org/antora/latest/asciidoc/subscript-and-superscript/[antora docs reference])
 
 == URL
 
-https://docs.antora.org/antora/latest/asciidoc/external-urls/[Antora docs reference^]
+https://docs.antora.org/antora/latest/asciidoc/external-urls/[antora docs reference]
 
 Looking for help?
 Visit the https://antora.zulipchat.com[Antora chat room].
@@ -27,7 +27,7 @@ This is the https://antora.zulipchat.com[external link^] for the same URL.
 
 == Xref
 
-https://docs.antora.org/antora/latest/asciidoc/in-page-xref/[Antora docs reference^]
+https://docs.antora.org/antora/latest/asciidoc/in-page-xref/[antora docs reference]
 
 This is an in-page cross reference for the previous Text section: <<_text>>.
 

--- a/preview-site-src/elements/table.adoc
+++ b/preview-site-src/elements/table.adoc
@@ -3,7 +3,7 @@
 :page-component-name: elements
 :page-notice-banner-message: This is a custom notice message about tables
 
-https://docs.asciidoctor.org/asciidoc/latest/tables/build-a-basic-table/[antora docs reference]
+https://docs.asciidoctor.org/asciidoc/latest/tables/build-a-basic-table/[Antora Docs Reference]
 
 == Basic Table
 

--- a/preview-site-src/elements/table.adoc
+++ b/preview-site-src/elements/table.adoc
@@ -3,7 +3,7 @@
 :page-component-name: elements
 :page-notice-banner-message: This is a custom notice message about tables
 
-https://docs.asciidoctor.org/asciidoc/latest/tables/build-a-basic-table/[Antora docs reference^]
+https://docs.asciidoctor.org/asciidoc/latest/tables/build-a-basic-table/[antora docs reference]
 
 == Basic Table
 

--- a/preview-site-src/elements/table.adoc
+++ b/preview-site-src/elements/table.adoc
@@ -3,7 +3,7 @@
 :page-component-name: elements
 :page-notice-banner-message: This is a custom notice message about tables
 
-https://docs.asciidoctor.org/asciidoc/latest/tables/build-a-basic-table/[Antora Docs Reference]
+https://docs.asciidoctor.org/asciidoc/latest/tables/build-a-basic-table/[Antora docs reference]
 
 == Basic Table
 

--- a/src/js/09-external-links.js
+++ b/src/js/09-external-links.js
@@ -4,8 +4,8 @@
   const uiRootPath = document.getElementById('site-script').dataset.uiRootPath
 
   const appendExternalLinkIcon = (link) => {
-    const isDataWeavePlaygroundLink = link && link.classList.contains('dw-playground-link')
-    const isFooterLink = link && link.offsetParent && link.offsetParent.tagName === 'FOOTER'
+    const isDataWeavePlaygroundLink = link?.classList.contains('dw-playground-link')
+    const isFooterLink = link?.offsetParent?.tagName === 'FOOTER'
     if (!isDataWeavePlaygroundLink && !isFooterLink) {
       const externalLinkImg = createLinkImage('external-link', 'Leaving the Site')
       link.appendChild(externalLinkImg)
@@ -24,11 +24,18 @@
     return img
   }
 
+  const isExternalLink = (url) => !url.startsWith(window.location.origin)
+
+  const opensInNewWindow = (linkTarget) => linkTarget === '_blank'
+
   const processExternalLinks = (selectors) => {
-    const selectorText = selectors.map((el) => `${el} [target="_blank"]`).join(', ')
+    const selectorText = selectors.map((el) => `${el} a`).join(', ')
     const externalLinks = document.querySelectorAll(selectorText)
     externalLinks.forEach((externalLink) => {
-      appendExternalLinkIcon(externalLink)
+      if (isExternalLink(externalLink.href)) {
+        if (!opensInNewWindow(externalLink.target)) externalLink.target = '_blank'
+        appendExternalLinkIcon(externalLink)
+      }
     })
   }
 


### PR DESCRIPTION
ref: W-14653224

The ask in the GUS ticket is to force all external links to open in new window, so that the writers don't have to add the `^` to each link.

There exists an script that adds an anchor icon to external links. Therefore, it is easy to just modify that script to capture all the links in the `.doc` and `.nav` areas (aka main viewport and left TOC), and check whether it is an external link (if the link does not start with `window.location.origin`). If it is an external link, then force it to open in a new window AND THEN add the anchor icon.

To validate, in the local preview site, I removed all the carets from the "Antora docs reference" links in multiple pages, and was able to validate that they still open in new windows + has the anchor icon.