### PR TITLE
[W-14270710] change tooltip triggering behavior

### DIFF
--- a/src/css/components/tooltip.css
+++ b/src/css/components/tooltip.css
@@ -24,8 +24,8 @@
 .tooltip-button {
   background: unset;
   border: none;
-  margin: auto;
   height: 16px;
+  margin: auto;
   padding: 0;
 
   & img {

--- a/src/css/components/tooltip.css
+++ b/src/css/components/tooltip.css
@@ -21,6 +21,18 @@
   }
 }
 
+.tooltip-button {
+  background: unset;
+  border: none;
+  margin: auto;
+  height: 16px;
+  padding: 0;
+
+  & img {
+    margin: 0;
+  }
+}
+
 .tooltip-dot {
   background-color: #5e8ef9;
   border-radius: 50%;

--- a/src/js/11-tooltip.js
+++ b/src/js/11-tooltip.js
@@ -9,11 +9,11 @@
     const tooltipDiv = createTooltipDiv()
     archiveLink.parentElement.appendChild(tooltipDiv)
 
-    const tooltipIcon = createTooltipIcon(archiveLink)
-    tooltipDiv.appendChild(tooltipIcon)
+    const tooltipButton = createTooltipButton(archiveLink)
+    tooltipDiv.appendChild(tooltipButton)
   }
 
-  const applyTippy = (icon, color) => {
+  const applyTippy = (button, icon, color) => {
     tippy(icon, {
       arrow: tippy.roundArrow,
       content: archiveTooltip,
@@ -22,6 +22,8 @@
       offset: [0, 15],
       theme: `${color}-archive-link-popover`,
       touchHold: true, // maps touch as click (for some reason)
+      trigger: 'click mouseenter',
+      triggerTarget: button,
       zIndex: 'var(--z-nav-mobile)',
     })
   }
@@ -32,22 +34,23 @@
     return tooltipDiv
   }
 
-  const createTooltipIcon = (archiveLink) => {
+  const createTooltipButton = (archiveLink) => {
+    const tooltipButton = document.createElement('button')
+    tooltipButton.classList.add('tooltip-button')
     const tooltipIcon = document.createElement('img')
     const iconColor = inLeftNav(archiveLink) ? 'gray' : 'white'
-    setIconAttributes(tooltipIcon, iconColor)
-    return tooltipIcon
+    setIconAttributes(tooltipButton, tooltipIcon, iconColor)
+    tooltipButton.appendChild(tooltipIcon)
+    return tooltipButton
   }
 
   const inLeftNav = (element) => element.classList.contains('nav-text')
 
-  const setIconAttributes = (icon, color) => {
+  const setIconAttributes = (button, icon, color) => {
     icon.classList.add('tooltip')
     icon.setAttribute('alt', 'Archived Documentation information')
-    icon.setAttribute('role', 'button')
-    icon.setAttribute('tabindex', '0')
     setSrcSVGPath(icon, color)
-    applyTippy(icon, color)
+    applyTippy(button, icon, color)
   }
 
   const setSrcSVGPath = (icon, color) => {

--- a/src/js/11-tooltip.js
+++ b/src/js/11-tooltip.js
@@ -37,11 +37,16 @@
   const createTooltipButton = (archiveLink) => {
     const tooltipButton = document.createElement('button')
     tooltipButton.classList.add('tooltip-button')
+    const tooltipIcon = createTooltipIcon(tooltipButton, archiveLink)
+    tooltipButton.appendChild(tooltipIcon)
+    return tooltipButton
+  }
+
+  const createTooltipIcon = (tooltipButton, archiveLink) => {
     const tooltipIcon = document.createElement('img')
     const iconColor = inLeftNav(archiveLink) ? 'gray' : 'white'
     setIconAttributes(tooltipButton, tooltipIcon, iconColor)
-    tooltipButton.appendChild(tooltipIcon)
-    return tooltipButton
+    return tooltipIcon
   }
 
   const inLeftNav = (element) => element.classList.contains('nav-text')


### PR DESCRIPTION
ref: [W-14270710](https://gus.lightning.force.com/a07EE00001cCXDaYAO)

Per LevelAccess (our accessibility audit vendor) on the tooltip next to Archived Documentation link:

> Now the [tooltip] element is announced as a button, but is expected to perform an action when pressed. So the tooltip shouldn't appear automatically when focused, instead wait until the button is activated. Right now screen readers are not reading the tooltip in a regular navigation, only when focused with tab key, and that's not the expected behavior.

This PR changes the triggering behavior based on the recommendation. Now the tooltip becomes an actual button and tooltip will show only when 1) mouse hover or 2) click/press enter or space key. Focusing on it via the tab key will not show the tooltip.

Can validate the triggering behavior via the local preview site, and inspect the tooltips circled in the following screenshot:

<img width="1090" alt="Screenshot 2024-01-23 at 9 47 19 AM" src="https://github.com/mulesoft/docs-site-ui/assets/10934908/6baae219-c439-4b69-a6a5-3f4b6c8a9574">


