### PR TITLE
[W-14491991] add feedback form char counter

### DIFF
--- a/src/css/adoc/doc-footer.css
+++ b/src/css/adoc/doc-footer.css
@@ -100,10 +100,9 @@
   & .feedback-form-textarea-character-count {
     display: inline-block;
     font-size: 12px;
-    margin-top: -13px;
     position: relative;
     text-align: right;
-    top: -15px;
+    top: -12px;
     width: 100%;
   }
 

--- a/src/css/adoc/doc-footer.css
+++ b/src/css/adoc/doc-footer.css
@@ -97,6 +97,16 @@
     }
   }
 
+  & .feedback-form-textarea-character-count {
+    display: inline-block;
+    font-size: 12px;
+    margin-top: -13px;
+    position: relative;
+    text-align: right;
+    top: -15px;
+    width: 100%;
+  }
+
   & .feedback-row {
     flex-flow: column;
     padding: var(--md) 13px;
@@ -138,7 +148,7 @@
   }
 
   & fieldset,
-  & span:not([aria-live], .validation-text, .feedback-form-thank-you) {
+  & span:not([aria-live], .validation-text, .feedback-form-textarea-character-count, .feedback-form-thank-you) {
     border: none;
     margin: auto;
     padding: 0 0 1em;

--- a/src/js/04-feedback.js
+++ b/src/js/04-feedback.js
@@ -5,6 +5,7 @@
   if (!feedbackCard) return
 
   const formSubmitAPIVersion = 'v1'
+  const maxCharCount = 800
 
   const questionSets = 'feedbackQuestions'
   const questionsMap = questionSets[formSubmitAPIVersion]
@@ -15,6 +16,8 @@
   const feedbackFormDiv = feedbackCard.querySelector('div.feedback-form')
   const feedbackForm = feedbackFormDiv?.querySelector('form')
   const feedbackFieldSet = feedbackForm?.querySelector('fieldset')
+  const feedbackFormTextarea = feedbackForm?.querySelector('textarea')
+  const feedbackFormTextareaCharCount = feedbackForm?.querySelector('span.feedback-form-textarea-character-count')
 
   const feedbackFormThankYouSign = feedbackCard.querySelector('span.feedback-form-thank-you')
 
@@ -73,6 +76,14 @@
             focusElement?.focus()
           }
         }
+      })
+    }
+
+    if (feedbackFormTextarea) {
+      initializeCharCount(feedbackFormTextareaCharCount)
+      feedbackFormTextarea.addEventListener('keyup', (e) => {
+        const currentCharCount = feedbackFormTextarea.value.length
+        feedbackFormTextareaCharCount.innerText = `${maxCharCount - currentCharCount} / ${maxCharCount}`
       })
     }
   }
@@ -158,6 +169,10 @@
     const lang = document.documentElement.lang
     const surveyIDLabel = Object.hasOwn(surveyIDsSet[lang], baseURL) ? surveyIDsSet[lang][baseURL] : fallbackSurveyID
     return `mulesoft_docs_${surveyIDLabel}`
+  }
+
+  const initializeCharCount = (CharCountSpan) => {
+    CharCountSpan.innerText = `${maxCharCount} / ${maxCharCount}`
   }
 
   const isHidden = (element) => element.offsetParent === null

--- a/src/js/04-feedback.js
+++ b/src/js/04-feedback.js
@@ -172,8 +172,8 @@
     return `mulesoft_docs_${surveyIDLabel}`
   }
 
-  const initializeCharCount = (CharCountSpan) => {
-    CharCountSpan.innerText = `${maxCharCount} / ${maxCharCount}`
+  const initializeCharCount = (charCountSpan) => {
+    charCountSpan.innerText = `${maxCharCount} / ${maxCharCount}`
   }
 
   const isHidden = (element) => element.offsetParent === null

--- a/src/js/04-feedback.js
+++ b/src/js/04-feedback.js
@@ -84,6 +84,7 @@
       feedbackFormTextarea.addEventListener('keyup', (e) => {
         const currentCharCount = feedbackFormTextarea.value.length
         feedbackFormTextareaCharCount.innerText = `${maxCharCount - currentCharCount} / ${maxCharCount}`
+        e.preventDefault()
       })
     }
   }

--- a/src/partials/feedback-form/written-feedback-section.hbs
+++ b/src/partials/feedback-form/written-feedback-section.hbs
@@ -8,6 +8,7 @@
             <textarea maxlength="800" placeholder="Tell us what you liked or didn't like." type="text" id="comment"
                 name="comment" rows="4"></textarea>
         </p>
+        <span class="feedback-form-textarea-character-count">1500 / 1500</span>
         <div class="feedback-form-button-row flex align-center justify-end">
             <input aria-label="Submit feedback" class="button-primary feedback-form-button" name="submit" type="submit"
                 value="Submit">

--- a/src/partials/feedback-form/written-feedback-section.hbs
+++ b/src/partials/feedback-form/written-feedback-section.hbs
@@ -5,7 +5,7 @@
         <fieldset></fieldset>
         <p>
             <label for="comment" class="feedback-title">Would you like to share any additional feedback? (Optional)</label>
-            <textarea maxlength="1000" placeholder="Tell us what you liked or didn’t like." type="text" id="comment"
+            <textarea maxlength="800" placeholder="Tell us what you liked or didn't like." type="text" id="comment"
                 name="comment" rows="4"></textarea>
         </p>
         <div class="feedback-form-button-row flex align-center justify-end">

--- a/src/partials/feedback-form/written-feedback-section.hbs
+++ b/src/partials/feedback-form/written-feedback-section.hbs
@@ -8,7 +8,7 @@
             <textarea maxlength="800" placeholder="Tell us what you liked or didn't like." type="text" id="comment"
                 name="comment" rows="4"></textarea>
         </p>
-        <span class="feedback-form-textarea-character-count">1500 / 1500</span>
+        <span class="feedback-form-textarea-character-count">800 / 800</span>
         <div class="feedback-form-button-row flex align-center justify-end">
             <input aria-label="Submit feedback" class="button-primary feedback-form-button" name="submit" type="submit"
                 value="Submit">

--- a/src/partials/feedback-form/written-feedback-section.hbs
+++ b/src/partials/feedback-form/written-feedback-section.hbs
@@ -8,7 +8,9 @@
             <textarea maxlength="800" placeholder="Tell us what you liked or didn't like." type="text" id="comment"
                 name="comment" rows="4"></textarea>
         </p>
-        <span class="feedback-form-textarea-character-count">800 / 800</span>
+        <span class="feedback-form-textarea-character-count">
+            {{!-- this value is initialized via clientside script --}}
+        </span>
         <div class="feedback-form-button-row flex align-center justify-end">
             <input aria-label="Submit feedback" class="button-primary feedback-form-button" name="submit" type="submit"
                 value="Submit">


### PR DESCRIPTION
ref: W-14491991

- lower maximum character count 1000 -> 800
- add a simple visible character counter, modeled after the form in https://help.tableau.com/current/prep/en-us/about-tableau-help.htm:

<img width="781" alt="Screenshot 2024-01-23 at 12 12 17 PM" src="https://github.com/mulesoft/docs-site-ui/assets/10934908/880b8ff9-a48b-4616-b368-def9c46832ca">
<img width="782" alt="Screenshot 2024-01-23 at 12 12 26 PM" src="https://github.com/mulesoft/docs-site-ui/assets/10934908/56b4a701-8ab3-42e7-adba-d9d8d9c7e0ae">
<img width="773" alt="Screenshot 2024-01-23 at 12 12 39 PM" src="https://github.com/mulesoft/docs-site-ui/assets/10934908/169e9cbc-8682-479b-8eb5-20b682e4cc6f">

Validated in local preview site (try http://localhost:8080/elements/admonition.html for reproduction). Tested the following:
- Once 800 characters have been added, no additional characters can be added
- Pasting content only pastes the first 800 characters
