### PR TITLE
[W-14901641] reorganize head scripts

### DIFF
--- a/src/partials/head/head-scripts.hbs
+++ b/src/partials/head/head-scripts.hbs
@@ -1,113 +1,15 @@
 {{#if (and env.GOOGLE_ANALYTICS_KEY (not preview))}}
-{{!--
-despite the Google analytics key label, the following script block is for segment rather than google analytics
-see https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/ for further info
---}}
-<script nonce="**CSP_NONCE**">
-  !function () {
-    var analytics = window.analytics = window.analytics || []; if (!analytics.initialize) if (analytics.invoked) window.console && console.error && console.error("Segment snippet included twice."); else {
-      analytics.invoked = !0; analytics.methods = ["trackSubmit", "trackClick", "trackLink", "trackForm", "pageview", "identify", "reset", "group", "track", "ready", "alias", "debug", "page", "once", "off", "on", "addSourceMiddleware", "addIntegrationMiddleware", "setAnonymousId", "addDestinationMiddleware"]; analytics.factory = function (e) { return function () { var t = Array.prototype.slice.call(arguments); t.unshift(e); analytics.push(t); return analytics } }; for (var e = 0; e < analytics.methods.length; e++) { var key = analytics.methods[e]; analytics[key] = analytics.factory(key) } analytics.load = function (key, e) { var t = document.createElement("script"); t.type = "text/javascript"; t.async = !0; t.src = "https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js"; var n = document.getElementsByTagName("script")[0]; n.parentNode.insertBefore(t, n); analytics._loadOptions = e }; analytics._writeKey = "{{env.GOOGLE_ANALYTICS_KEY}}";; analytics.SNIPPET_VERSION = "4.15.3";
-      analytics.load("{{env.GOOGLE_ANALYTICS_KEY}}");
-    }
-  }();
-</script>
-<!-- Google Tag Manager -->
-<script id="data-google-tag-manager" nonce="**CSP_NONCE**"
-  data-nonce="**CSP_NONCE**">(function (w, d, s, l, i) { w[l] = w[l] || []; w[l].push({ 'gtm.start': new Date().getTime(), event: 'gtm.js' }); var f = d.getElementsByTagName(s)[0], j = d.createElement(s), dl = l != 'dataLayer' ? '&l=' + l : ''; j.async = true; j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl; var n = d.querySelector('[nonce]'); n && j.setAttribute('nonce', n.nonce || n.getAttribute('nonce')); f.parentNode.insertBefore(j, f); })(window, document, 'script', 'dataLayer', 'GTM-NH8DNZL');</script>
-<script nonce="**CSP_NONCE**" async="" src="https://www.googletagmanager.com/gtm.js?id=GTM-NH8DNZL"></script>
-<!-- End Google Tag Manager -->
+  {{> gtm-scripts }}
+  {{> segment-script }}
 {{/if}}
-
-<!-- Script for common areas on-clicks -->
-<script src="https://www.mulesoft.com/onClicks/app.js" defer=""></script>
-
-<!-- Start VWO Async SmartCode -->
-<script nonce="**CSP_NONCE**">
-  window._vwo_code = window._vwo_code || (function () {
-    var account_id = 582086,
-      settings_tolerance = 2000,
-      library_tolerance = 2500,
-      use_existing_jquery = false,
-      is_spa = 1,
-      hide_element = 'body',
-      /* DO NOT EDIT BELOW THIS LINE */
-      f = false, d = document, code = {
-        use_existing_jquery: function () { return use_existing_jquery; }, library_tolerance: function () { return library_tolerance; }, finish: function () { if (!f) { f = true; var a = d.getElementById('_vis_opt_path_hides'); if (a) a.parentNode.removeChild(a); } }, finished: function () { return f; }, load: function (a) { var b = d.createElement('script'); b.src = a; b.type = 'text/javascript'; b.innerText; b.onerror = function () { _vwo_code.finish(); }; d.getElementsByTagName('head')[0].appendChild(b); }, init: function () {
-          window.settings_timer = setTimeout(function () { _vwo_code.finish() }, settings_tolerance); var a = d.createElement('style'), b = hide_element ? hide_element + '{opacity:0 !important;filter:alpha(opacity=0) !important;background:none !important;}' : '', h = d.getElementsByTagName('head')[0]; a.setAttribute('id', '_vis_opt_path_hides'); a.setAttribute('type', 'text/css'); if (a.styleSheet) a.styleSheet.cssText = b; else a.appendChild(d.createTextNode(b)); h.appendChild(a); this.load('https://dev.visualwebsiteoptimizer.com/j.php?a=' + account_id + '&u=' + encodeURIComponent(d.URL) + '&f=' + (+is_spa) + '&r=' + Math.random()); return settings_timer;
-        }
-      }; window._vwo_settings_timer = code.init(); return code;
-  }());
-</script>
-<!-- End VWO Async SmartCode -->
-
-{{!-- Coveo --}}
 {{#if (or env.COVEO_API_KEY env.COVEO_API_KEY_JP)}}
-<script type="module" src="https://static.cloud.coveo.com/atomic/v2.46/atomic.esm.js"></script>
-<script type="text/javascript" src="https://static.cloud.coveo.com/coveo.analytics.js/2/coveoua.js"></script>
-<script nonce="**CSP_NONCE**">
-  (async () => {
-    async function initSearch (organizationId, accessToken) {
-      await customElements.whenDefined("atomic-search-interface");
-      const searchInterface = document.querySelector("#search");
-      const organizationEndpoints = await searchInterface.getOrganizationEndpoints(organizationId)
-      await searchInterface.initialize({
-        accessToken,
-        organizationId,
-        organizationEndpoints,
-      });
-      if (window.location.href.includes('/search')) searchInterface.executeFirstSearch();
-    }
-    async function initCoveoUserAnalytics (organizationId, accessToken) {
-      coveoua("init", accessToken, `https://${organizationId}.analytics.org.coveo.com`);
-      coveoua("send", "view", {
-        contentIdKey: '@clickableUri',
-        contentIdValue: window.location.href,
-        contentType: 'Docs',
-      });
-    }
-    const organizationId = "mulesoftprodqzggq6re";
-    const accessToken = "{{env.COVEO_API_KEY}}";
-    const isProdSite = (hostname) => hostname === "docs.mulesoft.com";
-    initSearch(organizationId, accessToken);
-    if (isProdSite(window.location.hostname)) initCoveoUserAnalytics(organizationId, accessToken);
-  })();
-</script>
+  {{> coveo-search-scripts org_id="mulesoftprodqzggq6re"}}
 {{/if}}
-
-<script nonce="**CSP_NONCE**">
-  (async () => {
-    async function initContentRecommendations (organizationId, accessToken) {
-      if (onHomePage(window.location.pathname)) {
-        await customElements.whenDefined('atomic-recs-interface');
-        const recommendInterface = document.querySelector('#recs');
-        const organizationEndpoints = await recommendInterface.getOrganizationEndpoints(organizationId);
-        await recommendInterface.initialize({
-          accessToken,
-          organizationId,
-          organizationEndpoints,
-        });
-        recommendInterface.getRecommendations();
-      }
-    }
-    const organizationId = "mulesoftprodqzggq6re";
-    const crToken = "xxb149e86e-a23c-43f6-9840-95d0bfa55830"; // no need to hide this token - it has extremely limited privilege and will show in the source code anyway
-    const onHomePage = (pathName) => pathName === '/' || pathName.endsWith('/general/');
-    initContentRecommendations(organizationId, crToken);
-  })();
-</script>
-
-{{!-- The two blocks scripts are needed for hypothesis apps to open in the review site --}}
+{{#if (eq (site-profile) 'prod')}}
+  {{> coveo-ua-script org_id="mulesoftprodqzggq6re"}}
+{{/if}}
 {{#if (eq (site-profile) 'review' )}}
-<script type="application/json" class="js-hypothesis-config">
-  {
-    "openSidebar": true,
-    "openLoginForm": true
-  }
-</script>
-<script type="application/json" class="js-hypothesis-config">
-  {
-    "sidebarAppUrl": "https://dev-docs-review-h.kdev.msap.io/app.html"
-  }
-</script>
-<script async defer src="https://dev-docs-review-h.kdev.msap.io/embed.js"></script>
+  {{> review-site-scripts }}
 {{/if}}
+
+{{> vwo-script }}


### PR DESCRIPTION
ref: W-14901641

This PR reverts #649. #649 fixed the Google Analytics bug, but while inspecting the code some more, it was discovered that the google tag manager scripts (the ones needed for Google Analytics) was moved to a separate handlebar template file, and that file was accidentally omitted from the head-scripts.hbs. I have re-validated that the script and all other script files are now included.