### PR TITLE
[W-14457826] Add RSS link for release notes

### DIFF
--- a/preview-site-src/release-notes/by-date-index.adoc
+++ b/preview-site-src/release-notes/by-date-index.adoc
@@ -2,6 +2,7 @@
 ifndef::env-site,env-github[]
 endif::[]
 :keywords: release notes
+:page-subheading: rss
 
 [[october-22]]
 == October 2022

--- a/src/css/adoc/doc.css
+++ b/src/css/adoc/doc.css
@@ -16,6 +16,21 @@
     }
   }
 
+  & .subheading-row {
+    margin: var(--sm) 0;
+
+    & svg {
+      fill: var(--lume-c-icon-color-foreground-3);
+      margin-right: var(--sm);
+    }
+
+    & a:hover {
+      & svg {
+        fill: var(--lume-c-icon-color-foreground-1);
+      }
+    }
+  }
+
   /* numbered callouts from codeblocks */
   & .conum {
     background: #1a5492;
@@ -208,7 +223,7 @@
     }
 
     &:hover {
-      &:not(.anchor) {
+      &:not(.anchor, .link-subheading) {
         margin-left: -3px;
         margin-right: -3px;
         padding: 1px 3px;

--- a/src/js/05-analytics.js
+++ b/src/js/05-analytics.js
@@ -4,4 +4,6 @@
   if (!window.analytics) return
   const trackGithub = () => window.analytics.track('Clicked GitHub Link', { url: window.location.href })
   document.querySelectorAll('.github').forEach((githubLink) => githubLink.addEventListener('click', trackGithub))
+  const trackRSS = () => window.analytics.track('Clicked RSS Link')
+  document.querySelectorAll('.release-notes-rss').forEach((rssLink) => rssLink.addEventListener('click', trackRSS))
 })()

--- a/src/partials/article/article.hbs
+++ b/src/partials/article/article.hbs
@@ -5,6 +5,7 @@
     {{#if page.title}}
     <h1 class="page">{{{page.title}}}</h1>
     {{/if}}
+    {{> subheading}}
     {{> deployment-options}}
     {{{page.contents}}}
     {{> pagination}}

--- a/src/partials/subheading/do-rss.hbs
+++ b/src/partials/subheading/do-rss.hbs
@@ -1,0 +1,9 @@
+<a class="link-subheading align-center flex" href="https://docs.mulesoft.com/releases.rss" title="Add this URL to your RSS feed reader to stay up to date with MuleSoft releases.">
+    <svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 504.4 504.4" xml:space="preserve">
+        <path d="M377.6,0.2H126.4C56.8,0.2,0,57,0,126.6v251.6c0,69.2,56.8,126,126.4,126H378c69.6,0,126.4-56.8,126.4-126.4V126.6
+            C504,57,447.2,0.2,377.6,0.2z M136.8,409c-23.2,0-42-18.8-42-41.6c0-23.2,18.8-41.6,42-41.6c23.2,0,42,18.8,42,41.6
+            C178.8,390.2,160,409,136.8,409z M242,408.2c0-40-14.8-76-42.4-103.6c-28-28-63.6-42.4-103.6-42.4v-60.4
+            c112,0,206.4,94.4,206.4,206.4H242z M348.8,408.2c0-140-112.8-252.8-252.8-252.8V95c172,0,313.2,141.2,313.2,313.2H348.8z"/>
+    </svg>
+    Release Note RSS Feed
+</a>

--- a/src/partials/subheading/do-rss.hbs
+++ b/src/partials/subheading/do-rss.hbs
@@ -1,4 +1,4 @@
-<a class="link-subheading align-center flex" href="https://docs.mulesoft.com/releases.rss" title="Add this URL to your RSS feed reader to stay up to date with MuleSoft releases.">
+<a class="release-notes-rss link-subheading align-center flex" href="https://docs.mulesoft.com/releases.rss" title="Add this URL to your RSS feed reader to stay up to date with MuleSoft releases.">
     <svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 504.4 504.4" xml:space="preserve">
         <path d="M377.6,0.2H126.4C56.8,0.2,0,57,0,126.6v251.6c0,69.2,56.8,126,126.4,126H378c69.6,0,126.4-56.8,126.4-126.4V126.6
             C504,57,447.2,0.2,377.6,0.2z M136.8,409c-23.2,0-42-18.8-42-41.6c0-23.2,18.8-41.6,42-41.6c23.2,0,42,18.8,42,41.6

--- a/src/partials/subheading/do-rss.hbs
+++ b/src/partials/subheading/do-rss.hbs
@@ -1,9 +1,9 @@
-<a class="release-notes-rss link-subheading align-center flex" href="https://docs.mulesoft.com/releases.rss" title="Add this URL to your RSS feed reader to stay up to date with MuleSoft releases.">
+<a class="release-notes-rss link-subheading flex" href="https://docs.mulesoft.com/releases.rss" title="Add this URL to your RSS feed reader to stay up to date with MuleSoft releases.">
     <svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 504.4 504.4" xml:space="preserve">
         <path d="M377.6,0.2H126.4C56.8,0.2,0,57,0,126.6v251.6c0,69.2,56.8,126,126.4,126H378c69.6,0,126.4-56.8,126.4-126.4V126.6
             C504,57,447.2,0.2,377.6,0.2z M136.8,409c-23.2,0-42-18.8-42-41.6c0-23.2,18.8-41.6,42-41.6c23.2,0,42,18.8,42,41.6
             C178.8,390.2,160,409,136.8,409z M242,408.2c0-40-14.8-76-42.4-103.6c-28-28-63.6-42.4-103.6-42.4v-60.4
             c112,0,206.4,94.4,206.4,206.4H242z M348.8,408.2c0-140-112.8-252.8-252.8-252.8V95c172,0,313.2,141.2,313.2,313.2H348.8z"/>
     </svg>
-    Release Note RSS Feed
+    RSS Feed
 </a>

--- a/src/partials/subheading/subheading.hbs
+++ b/src/partials/subheading/subheading.hbs
@@ -1,0 +1,5 @@
+{{#if page.attributes.subheading}}
+<div class="subheading-row flex flex-wrap">
+    {{#if (eq page.attributes.subheading 'rss')}} {{> do-rss}} {{/if}}
+</div>
+{{/if}}


### PR DESCRIPTION
This PR adds an RSS link on pages that include the `:page-subheading: rss` attribute. 

![Screenshot 2024-02-01 at 12 10 35 PM](https://github.com/mulesoft/docs-site-ui/assets/5760201/03ba0e34-50ad-4237-b20e-4508d351d3fc)

You can see the companion PR that adds that attribute to the release notes by-date page here:

https://github.com/mulesoft/docs-release-notes/pull/7863

Note that I've also added a tracking link modeled after our GitHub link, however I can't currently confirm the data is appearing until my access request goes through. Added a note to our existing tracking data spike to follow up on this.

