### PR TITLE
[W-14955010] Replace meta tag for google site ownership verification

### DIFF
--- a/src/partials/head/head-meta.hbs
+++ b/src/partials/head/head-meta.hbs
@@ -52,9 +52,7 @@
     <meta name="description" content="MuleSoft Documentation Site">
 {{/if}}
 
-{{#with site.keys.googleSiteVerification}}
-    <meta name="google-site-verification" content="{{this}}">
-{{/with}}
+<meta name="google-site-verification" content="NDIrUbizqamSncO6tSzBUHFR8VIKcjAocR4UrnKau2s" />
 
 {{#if (or antoraVersion site.antoraVersion)}}
     <meta name="generator" content="Antora {{or antoraVersion site.antoraVersion}}">


### PR DESCRIPTION
After digging into how we can verify site ownership in Google Search Console, I realized that one of the methods was to add a meta tag to our pages (and moreover we were doing this previously as I found the old meta tags). Before, the meta tag was only being filled in on the prod site as it was the only site that had the key defined in the antora playbook. Since we now want to be able to verify all our sites, I'm adding the meta tag as default on all our pages. Note that Google does not generate different codes per site--rather the code is the same per account, so the one line in this PR _should_ be enough.

I'm also removing the old verification code from our playbook in the following PR:
https://github.com/mulesoft/docs-site-playbook/pull/2225