### PR TITLE
[W-15060125] bugfix - remove duplicate "Filter by Products" facet in mobile view

### DIFF
--- a/preview-site-src-jp/jp/general/index.adoc
+++ b/preview-site-src-jp/jp/general/index.adoc
@@ -88,7 +88,7 @@ image::monitor.png[alt=""]
 
 == クイックリンク
 
-[#popular-topics]
+[#trending-topics]
 == 人気のあるトピック
 
 //Date Range 5/01/2022 - 6/01/2022 (omits #1 ranking link to landing page, of course)

--- a/preview-site-src-jp/jp/index.adoc
+++ b/preview-site-src-jp/jp/index.adoc
@@ -85,7 +85,7 @@ image::monitor.png[alt=""]
 
 == クイックリンク
 
-[#popular-topics]
+[#trending-topics]
 == 人気のあるトピック
 
 //Date Range 5/01/2022 - 6/01/2022 (omits #1 ranking link to landing page, of course)

--- a/preview-site-src/index.adoc
+++ b/preview-site-src/index.adoc
@@ -85,7 +85,7 @@ Monitor your APIs and integrations using dashboards, metrics, and visualization.
 
 == Quick Links
 
-[#popular-topics]
+[#trending-topics]
 == Trending Topics
 
 //Date Range 5/01/2022 - 6/01/2022 (omits #1 ranking link to landing page, of course)

--- a/src/js/21-coveo-facets.js
+++ b/src/js/21-coveo-facets.js
@@ -7,11 +7,10 @@
   let tries = 500
 
   const addVersionFacets = () => {
-    const atomicFacetManager = atomicFacetsLayoutSection.querySelector('atomic-facet-manager')
     const components = window.siteNavigationData
     components.forEach((component) => {
       const versionFacet = createVersionFacet(component.name, component.title, component.versions)
-      if (versionFacet) atomicFacetManager.appendChild(versionFacet)
+      if (versionFacet) atomicFacetsLayoutSection.appendChild(versionFacet)
     })
     delete window.siteNavigationData
   }

--- a/src/partials/landing-page/landing-page.hbs
+++ b/src/partials/landing-page/landing-page.hbs
@@ -7,7 +7,7 @@
   </header>
   {{#if (eq (site-profile) 'jp' )}}
   <div class='panel single-panel'>
-    {{{page.contents.popular-topics}}}
+    {{{page.contents.trending-topics}}}
   </div>
   {{else}}
   <div class='panels'>

--- a/src/partials/search/search-interface.hbs
+++ b/src/partials/search/search-interface.hbs
@@ -7,7 +7,6 @@
     <atomic-search-layout>
       <atomic-layout-section section="facets">
       <atomic-facet facet-id="product" field="product" heading-level=2 label="{{#if (eq (site-profile) 'jp')}}製品別に絞り込み{{else}}Filter by Product{{/if}}"></atomic-facet>
-      <atomic-facet-manager></atomic-facet-manager>
       </atomic-layout-section>
       <atomic-layout-section section="main">
         <atomic-layout-section section="status">


### PR DESCRIPTION
ref: [W-15060125](https://gus.lightning.force.com/a07EE00001kITqGYAW)

fix bug. the [atomic-facet-manager](https://docs.coveo.com/en/atomic/latest/reference/components/atomic-facet-manager/) is supposed to automatically manager the order of the facets, but somehow it added the extra duplicate facet. After I removed it, this bug was fixed.