### PR TITLE
[W-15022269] harden Coveo UA script

### DIFF
--- a/src/partials/head/head-scripts.hbs
+++ b/src/partials/head/head-scripts.hbs
@@ -4,8 +4,6 @@
 {{/if}}
 {{#if (or env.COVEO_API_KEY env.COVEO_API_KEY_JP)}}
   {{> coveo-search-scripts org_id="mulesoftprodqzggq6re"}}
-{{/if}}
-{{#if (and (is-one-of (site-profile) "jp" "prod") (or env.COVEO_API_KEY env.COVEO_API_KEY_JP))}}
   {{> coveo-ua-script org_id="mulesoftprodqzggq6re"}}
 {{/if}}
 {{#if (eq (site-profile) 'review' )}}

--- a/src/partials/head/head-scripts.hbs
+++ b/src/partials/head/head-scripts.hbs
@@ -5,7 +5,7 @@
 {{#if (or env.COVEO_API_KEY env.COVEO_API_KEY_JP)}}
   {{> coveo-search-scripts org_id="mulesoftprodqzggq6re"}}
 {{/if}}
-{{#if (eq (site-profile) 'prod')}}
+{{#if (is-one-of (site-profile) "jp" "prod")}}
   {{> coveo-ua-script org_id="mulesoftprodqzggq6re"}}
 {{/if}}
 {{#if (eq (site-profile) 'review' )}}

--- a/src/partials/head/head-scripts.hbs
+++ b/src/partials/head/head-scripts.hbs
@@ -5,7 +5,7 @@
 {{#if (or env.COVEO_API_KEY env.COVEO_API_KEY_JP)}}
   {{> coveo-search-scripts org_id="mulesoftprodqzggq6re"}}
 {{/if}}
-{{#if (is-one-of (site-profile) "jp" "prod")}}
+{{#if (and (is-one-of (site-profile) "jp" "prod") (or env.COVEO_API_KEY env.COVEO_API_KEY_JP))}}
   {{> coveo-ua-script org_id="mulesoftprodqzggq6re"}}
 {{/if}}
 {{#if (eq (site-profile) 'review' )}}

--- a/src/partials/head/head-scripts/coveo-ua-script.hbs
+++ b/src/partials/head/head-scripts/coveo-ua-script.hbs
@@ -15,6 +15,7 @@
 
     const isProdSite = (hostname) => hostname === "docs.mulesoft.com";
 
-    if (isProdSite(window.location.hostname)) initCoveoUserAnalytics(organizationId, accessToken);
+    if (isProdSite(window.location.hostname))
+    if (accessToken) initCoveoUserAnalytics(organizationId, accessToken);
   })();
 </script>

--- a/src/partials/head/head-scripts/coveo-ua-script.hbs
+++ b/src/partials/head/head-scripts/coveo-ua-script.hbs
@@ -15,7 +15,8 @@
 
     const isProdSite = (hostname) => hostname === "docs.mulesoft.com";
 
-    if (isProdSite(window.location.hostname))
-    if (accessToken) initCoveoUserAnalytics(organizationId, accessToken);
+    if (isProdSite(window.location.hostname)) {
+      if (accessToken) initCoveoUserAnalytics(organizationId, accessToken);
+    }
   })();
 </script>


### PR DESCRIPTION
ref: W-15022269

- simplify the logic of having the Coveo UA script by checking for the existence of a Coveo API key environment variable rather than the site profile. The site profile is already being checked in the actual UA script so it's redundant
- harden the UA script so that Coveo UA is initialized only if a Coveo API key is found 