### PR TITLE
[W-15145820] Localize single-version badge text

### DIFF
--- a/src/js/01-nav.js
+++ b/src/js/01-nav.js
@@ -7,6 +7,7 @@
 
   const homeTitle = MSCX.l10n.getMessage('left-nav-home-title')
   const currentVersion = MSCX.l10n.getMessage('left-nav-current-version')
+  const currentAndOnlyVersion = MSCX.l10n.getMessage('left-nav-current-only-version')
   const latestVersion = MSCX.l10n.getMessage('left-nav-latest-version')
   const previousVersions = MSCX.l10n.getMessage('left-nav-previous-versions')
 
@@ -633,7 +634,7 @@
       if (versions.length === 1) {
         navVersionButton = createElement('p.prev-flag')
         navVersionButton.textContent = activeDisplayVersion
-        navVersionButton.title = `${activeDisplayVersion} is the current and only version of ${componentData.title}`
+        navVersionButton.title = currentAndOnlyVersion
       } else {
         navVersionButton = createElement('button.nav-version-button')
         navVersionButton.setAttribute('tabindex', '-1')

--- a/src/locales/messages.json
+++ b/src/locales/messages.json
@@ -12,6 +12,7 @@
       "landing-footer-archive-tooltip": "When a product version is no longer supported, including products with end-of-life status, its documentation moves to an archive site.",
       "latest": "latest",
       "left-nav-current-version": "Current version",
+      "left-nav-current-only-version": "This is the current and only version.",
       "left-nav-home-title": "Home",
       "left-nav-latest-version": "This is the latest version.",
       "left-nav-previous-versions": "Previous versions",


### PR DESCRIPTION
This PR moves the text for single-version badges, in other words version badges in the left nav without a drop-down, into our list of localized messages.

Here's what that looks like:
![Screenshot 2024-03-04 at 12 20 10 PM](https://github.com/mulesoft/docs-site-ui/assets/5760201/6cb59939-025f-47b7-b7d9-6ea9fd07164a)

Note that the text has been made more generic to avoid issues with translating interpolated text. I've added this string to our upcoming handoff.
