### PR TITLE
[W-15052351] Wrap JP Xrefs in Brackets

### DIFF
--- a/src/js/00-globals.js
+++ b/src/js/00-globals.js
@@ -25,6 +25,10 @@ MSCX.l10n = (function () {
     }
   }
 
+  function lookupLocale () {
+    return locale
+  }
+
   function lookupMessage (messageKey) {
     if (!(messageKey in messages)) {
       console.error(`Missing UI string: ${messageKey}`)
@@ -79,5 +83,6 @@ MSCX.l10n = (function () {
 
   return {
     getMessage: lookupMessage,
+    getLocale: lookupLocale,
   }
 })()

--- a/src/js/24-jp-processing.js
+++ b/src/js/24-jp-processing.js
@@ -24,12 +24,18 @@
     return false
   }
 
+  function linkAlreadyContainsBrackets (linkElement) {
+    const linkText = linkElement.textContent
+    return linkText.includes('「') || linkText.includes('」') || linkText.includes('『') || linkText.includes('』')
+  }
+
   // Does not work in preview builds, only full builds include xref class above
   function wrapXrefLinksInJpBrackets () {
     xrefLinks.forEach((link) => {
       const linkUrl = new URL(link.href)
 
       if (!linkContainsText(link)) return
+      if (linkAlreadyContainsBrackets(link)) return
       if (linkIsOnlyContentInParent(link)) return
 
       if (linkUrl.hash) {

--- a/src/js/24-jp-processing.js
+++ b/src/js/24-jp-processing.js
@@ -1,0 +1,44 @@
+/* eslint-disable no-var */
+;(() => {
+  'use strict'
+
+  if (MSCX.l10n.getLocale() !== 'jp') {
+    return
+  }
+
+  const xrefLinks = document.querySelectorAll('article a.xref')
+
+  function linkContainsText (linkElement) {
+    const hasText = linkElement.textContent.trim().length > 0
+    return hasText
+  }
+
+  function linkIsOnlyContentInParent (linkElement) {
+    const parentElement = linkElement.parentElement
+
+    if (parentElement) {
+      const childNodes = parentElement.childNodes
+      return childNodes.length === 1 && childNodes[0] === linkElement
+    }
+
+    return false
+  }
+
+  // Does not work in preview builds, only full builds include xref class above
+  function wrapXrefLinksInJpBrackets () {
+    xrefLinks.forEach((link) => {
+      const linkUrl = new URL(link.href)
+
+      if (!linkContainsText(link)) return
+      if (linkIsOnlyContentInParent(link)) return
+
+      if (linkUrl.hash) {
+        link.innerHTML = `「${link.innerHTML}」`
+      } else {
+        link.innerHTML = `『${link.innerHTML}』`
+      }
+    })
+  }
+
+  wrapXrefLinksInJpBrackets()
+})()


### PR DESCRIPTION
For JP content only, wrap link text in Japanese brackets to match the localization style guide. Here's the guidelines we've received:

* Any section heading of a cross-reference needs to be bracketed with 「 and 」. (I'm taking this to mean links to page anchors, as those would be headings for a section.)
* Any document heading of a cross-reference needs to be bracketed with 『 and 』. (I'm taking this to mean direct links to pages.)
* Any cross-reference that occupies a whole block element (e.g. a list item or a table cell) should not be bracketed.

Additionally, I discovered during testing that there are several cases where bracket quotes were already added to link text manually during translation. As a result, I'm skipping wrapping if the text already contains brackets.

Tested in local preview build and with full JP and EN builds (to confirm that this does not impact EN content). Example screenshots below.

Brackets wrapping an xref:
![Screenshot 2024-04-12 at 1 30 39 PM](https://github.com/mulesoft/docs-site-ui/assets/5760201/9dfafb0d-f6bb-4e4c-aa97-847128994b5b)

No brackets when the xref is the only content in a list or table:
![Screenshot 2024-04-12 at 1 30 27 PM](https://github.com/mulesoft/docs-site-ui/assets/5760201/74e7e9cb-4422-4c99-af25-c877e5c526cd)


No brackets for non-xrefs:
![Screenshot 2024-04-12 at 1 32 21 PM](https://github.com/mulesoft/docs-site-ui/assets/5760201/94ece99f-148c-4046-9588-dc18b14caf9a)

