### PR TITLE
[W-15363939] Fix external link icon sizing in notice banners

### DIFF
--- a/preview-site-src/elements/element-examples.adoc
+++ b/preview-site-src/elements/element-examples.adoc
@@ -1,8 +1,9 @@
 = Elements
 :page-component-name: elements
-:page-notice-banner-message: This is a custom notice message
+:page-notice-banner-message: <strong>Custom Notice Banner:</strong> Enablement status is available in Anypoint Platform from <a href="https://anypoint.mulesoft.com/codebuilder/" target="_blank" rel="noopener">Anypoint Code Builder<img role="link" class="external-link-image" src="../_/img/icons/external-link.svg" alt="Leaving the Site" title="Leaving the Site"></a>
 
 This page contains different elements like tables, code blocks, etc. so you can verify that everything looks ok.
+
 
 == Table
 

--- a/src/css/specific/banner.css
+++ b/src/css/specific/banner.css
@@ -23,6 +23,10 @@
     filter: grayscale(100%) brightness(0);
     height: 22px;
     margin: auto 10px;
+
+    & .external-link-image {
+      height: 12px;
+    }
   }
 
   & .close-button {


### PR DESCRIPTION
When external links are added to notice banners, the link icon is too big.

Before:
![Screenshot 2024-04-15 at 8 19 50 AM](https://github.com/mulesoft/docs-site-ui/assets/5760201/908c7dce-6758-4b7c-a1ab-36e4a5d2a58b)

After:
![Screenshot 2024-04-15 at 8 38 38 AM](https://github.com/mulesoft/docs-site-ui/assets/5760201/4ff3c7d9-6a87-4445-81a6-a2a93ce6151c)

Tested on preview site only as this issue does not exist on beta (yet). This is something a writer will be adding soon.
