### PR TITLE
[W-14944827] Fix: Breadcrumbs showing version twice

### DIFF
--- a/src/js/13-breadcrumbs.js
+++ b/src/js/13-breadcrumbs.js
@@ -103,10 +103,19 @@
     originalExpandState = undefined
   }
 
+  const onlyShowFirstBreadcrumbVersion = () => {
+    const breadcrumbItems = document.querySelectorAll('.breadcrumbs-item-version')
+
+    for (let i = 1; i < breadcrumbItems.length; i++) {
+      breadcrumbItems[i].style.display = 'none'
+    }
+  }
+
   if (isHomePage(window.location.pathname)) {
     hideToolbar(document.querySelector('.toolbar'))
   } else {
     scrollRight(breadcrumbs)
     addListeners()
   }
+  onlyShowFirstBreadcrumbVersion()
 })()

--- a/src/partials/toolbar/breadcrumbs.hbs
+++ b/src/partials/toolbar/breadcrumbs.hbs
@@ -13,14 +13,14 @@
   </li>
   {{#with page.componentVersion}}
   {{#if (and ./title (not ./root) (not (is-one-of ./title 'Home' 'ホーム')) (ne ./url @root.page.url))}}
-  <li class="flex align-center li"><a class="link" href="{{{relativize ./url}}}">{{{./title}}}{{#if (and (not (is-null @root.page.version)) (not (is-one-of @root.page.version 'default' 'latest' 'master' '~')))}} ({{ @root.page.version }}){{/if}}</a></li>
+  <li class="flex align-center li"><a class="link" href="{{{relativize ./url}}}">{{{./title}}}{{#if (and (not (is-null @root.page.version)) (not (is-one-of @root.page.version 'default' 'latest' 'master' '~')))}} <span class="breadcrumbs-item-version">({{ @root.page.version }})</span>{{/if}}</a></li>
   {{/if}}
   {{/with}}
   {{#each page.breadcrumbs}}
   {{#if (eq ./urlType 'internal')}}
     {{#if (eq ./url @root.page.url)}}
     <li class="flex align-center li">
-      <p>{{{./content}}}{{#if (and (not (is-null @root.page.version)) (not (is-one-of @root.page.version 'default' 'latest' 'master' '~')) (or (eq ./url @root.page.breadcrumbs.0.url) (and (ends-with ./url "index.html"))))}} ({{ @root.page.version }}){{/if}}</p>
+      <p>{{{./content}}}{{#if (and (not (is-null @root.page.version)) (not (is-one-of @root.page.version 'default' 'latest' 'master' '~')) (or (eq ./url @root.page.breadcrumbs.0.url) (and (ends-with ./url "index.html"))))}} <span class="breadcrumbs-item-version">({{ @root.page.version }})</span>{{/if}}</p>
     </li>
     {{else if (ne ./url @root.page.breadcrumbs.0.url)}}
     <li class="flex align-center li"><a class="link" href="{{{relativize ./url}}}">{{{./content}}}</a></li>


### PR DESCRIPTION
This issue seems to be limited to children of the Gateway node in our docs, as the nesting is different. Here's what the issue looks like:
![Screenshot 2024-04-30 at 9 18 54 AM](https://github.com/mulesoft/docs-site-ui/assets/5760201/c1d9792d-185d-4d20-a93b-e75dc1a60068)

Fixing this by simply setting display none on any duplicate versions in the breadcrumbs. Tested in the preview site.
![Screenshot 2024-04-30 at 9 21 29 AM](https://github.com/mulesoft/docs-site-ui/assets/5760201/f2e043dd-76a7-4c55-85d7-77d52c01edc2)
