### PR TITLE
[W-15059890] Fix: Mobile breadcrumbs drawer not always toggling

### DIFF
--- a/src/css/specific/toolbar.css
+++ b/src/css/specific/toolbar.css
@@ -16,7 +16,7 @@
     padding-right: var(--xl);
   }
 
-  & button:not(.search-page-back-button) {
+  & button:not(.search-page-back-button, .breadcrumbs-toggle) {
     height: 30px;
     min-height: unset;
   }

--- a/src/js/13-breadcrumbs.js
+++ b/src/js/13-breadcrumbs.js
@@ -115,7 +115,7 @@
     hideToolbar(document.querySelector('.toolbar'))
   } else {
     scrollRight(breadcrumbs)
-    addListeners()
   }
+  addListeners()
   onlyShowFirstBreadcrumbVersion()
 })()


### PR DESCRIPTION
This PR fixes two issues:

* On mobile, the docs site shows a breadcrumbs toolbar on some pages where the desktop site does not show breadcrumbs. As a result, the breadcrumbs event listeners aren't being registered on those pages, which leads to the toggle button not working. Fixed this by moving a function call so that it always registers event listeners for breadcrumbs.
* The toggle button is stretched into an oblong shape. Fixed this by editing the toolbar CSS to exclude the toggle button, as its higher specificity was overriding the button height defined elsewhere.

Tested in preview build and in full playbook build.