### PR TITLE
[W-15633514] update site title

### DIFF
--- a/preview-site-src/ui-model.yml
+++ b/preview-site-src/ui-model.yml
@@ -9,7 +9,7 @@ asciidoc:
 site:
   url: &index_url /
   homeUrl: *index_url
-  title: MuleSoft Documentation
+  title: MuleSoft
   keys: {
   ## uncomment the following line to switch site-profile to jp
     # siteProfile: 'jp'

--- a/src/layouts/404.hbs
+++ b/src/layouts/404.hbs
@@ -4,7 +4,7 @@
 <head>
     <title>
         {{#if (eq (site-profile) 'jp')}}ページが見つかりません{{else}}Page Not Found{{/if}}
-        {{#if site.title}} | {{{site.title}}}{{/if}}
+        {{#if site.title}} - {{{site.title}}}{{/if}}
     </title>
     {{> head}}
 </head>

--- a/src/layouts/connectors-home.hbs
+++ b/src/layouts/connectors-home.hbs
@@ -2,7 +2,7 @@
 <html lang={{#if (eq (site-profile) 'jp' )}}"jp"{{else}}"en"{{/if}}>
 
 <head>
-  <title>{{{detag (or page.title 'Untitled')}}}{{#if site.title}} | {{{site.title}}}{{/if}}</title>
+  <title>{{{detag (or page.title 'Untitled')}}}{{#if site.title}} - {{{site.title}}}{{/if}}</title>
   {{> head}}
 </head>
 

--- a/src/layouts/default.hbs
+++ b/src/layouts/default.hbs
@@ -2,7 +2,7 @@
 <html lang={{#if (eq (site-profile) 'jp' )}}"jp"{{else}}"en"{{/if}}>
 
 <head>
-  <title>{{{detag (or page.title 'Untitled')}}}{{#if site.title}} | {{{site.title}}}{{/if}}</title>
+  <title>{{{detag (or page.title 'Untitled')}}}{{#if site.title}} - {{{site.title}}}{{/if}}</title>
   {{> head}}
 </head>
 

--- a/src/layouts/home.hbs
+++ b/src/layouts/home.hbs
@@ -2,7 +2,7 @@
 <html lang={{#if (eq (site-profile) 'jp' )}}"jp"{{else}}"en"{{/if}}>
 
 <head>
-    <title>{{{detag (or page.title 'Untitled')}}}{{#if site.title}} | {{{site.title}}}{{/if}}</title>
+    <title>{{{detag (or page.title 'Untitled')}}}{{#if site.title}} - {{{site.title}}}{{/if}}</title>
     {{> head}}
 </head>
 

--- a/src/layouts/maintenance.hbs
+++ b/src/layouts/maintenance.hbs
@@ -2,7 +2,7 @@
 <html lang={{#if (eq (site-profile) 'jp' )}}"jp"{{else}}"en"{{/if}}>
 
 <head>
-    <title>{{{detag (or page.title 'Untitled')}}}{{#if site.title}} | {{{site.title}}}{{/if}}</title>
+    <title>{{{detag (or page.title 'Untitled')}}}{{#if site.title}} - {{{site.title}}}{{/if}}</title>
     {{> head}}
 </head>
 

--- a/src/layouts/search-page.hbs
+++ b/src/layouts/search-page.hbs
@@ -2,7 +2,7 @@
 <html lang={{#if (eq (site-profile) 'jp' )}}"jp"{{else}}"en"{{/if}}>
 
 <head>
-    <title>{{{detag (or page.title 'Untitled')}}}{{#if site.title}} | {{{site.title}}}{{/if}}</title>
+    <title>{{{detag (or page.title 'Untitled')}}}{{#if site.title}} - {{{site.title}}}{{/if}}</title>
     {{> head}}
 </head>
 


### PR DESCRIPTION
ref: W-15633514

change the site title format from `<page_name> | MuleSoft Documentation` to `<page_name> - MuleSoft` to match the format of Tableau Docs, so they show in the same format in Salesforce's search results.