### PR TITLE
[W-15921470] update coveo ua payload

### DIFF
--- a/src/partials/head/head-scripts/coveo-ua-script.hbs
+++ b/src/partials/head/head-scripts/coveo-ua-script.hbs
@@ -5,8 +5,10 @@
       coveoua("init", accessToken, `https://${organizationId}.analytics.org.coveo.com`);
       coveoua("send", "view", {
         contentIdKey: '@clickableUri',
-        contentIdValue: window.location.href,
+        contentIdValue: `${window.location.origin}${window.location.pathname}`,
         contentType: 'Docs',
+        language: "{{#if (eq (site-profile) 'jp')}}ja{{else}}en{{/if}}",
+        location: `${window.location.origin}${window.location.pathname}`
       });
     }
     


### PR DESCRIPTION
ref: [W-15921470](https://gus.lightning.force.com/a07EE00001tQkKQYA0)

This is related to the issue where Coveo UA is not receiving (or processing) any view events for JP site pages. Upon looking at the [Event Errors](https://platform.cloud.coveo.com/admin/#/mulesoftprodqzggq6re/usage/health/event-problems) page, there are 2 types of errors that I saw that prevent the JP site view events from being processed:
1. language doesn't match. `jp` is not valid, `ja` is ([source: Coveo doc](https://docs.coveo.com/en/1956/index-content/supported-languages#machine-learning-features-support))
2. URL sometimes is invalid. I see that some of the JP site characters are sometimes not encoded properly and they get rejected

So based on these errors, I update some of the payload data so they are more compatible.