### PR TITLE
[W-15230132] Fix: Archive connectors landing page missing connectors

### DIFF
--- a/src/helpers/connectors.js
+++ b/src/helpers/connectors.js
@@ -5,7 +5,32 @@ module.exports = function ({
     root: { site },
   },
 }) {
-  return Object.values(site.components).filter(
-    ({ asciidoc = { attributes: {} } }) => asciidoc.attributes['page-connector-type']
-  )
+  function getLocalConnectorComponents (components) {
+    const connectors = {}
+
+    for (const component in components) {
+      if (component.endsWith('-connector')) {
+        const connector = components[component]
+        // Filter out connector versions that are missing the page-connector-type attribute.
+        // These are imported from the site manifest with the @antora/atlas-extension in the playbook,
+        // and should not display in the build.
+        const filteredVersions = connector.versions.filter(
+          (version) => version.asciidoc.attributes['page-connector-type']
+        )
+
+        if (filteredVersions.length === 0) {
+          continue
+        }
+
+        // Replace latest with a local version, rather than the latest imported version
+        connector.latest = filteredVersions[0]
+        connector.versions = filteredVersions
+        connectors[component] = connector
+      }
+    }
+
+    return connectors
+  }
+
+  return getLocalConnectorComponents(site.components)
 }


### PR DESCRIPTION
The [connectors landing page](https://archive.docs.mulesoft.com/connectors/) for the archive site does not show all the connectors available. This was a strange one to debug as side-by-side comparisons of the content did not yield any noticeable differences, and the code in this repo does not have any special template for the archive connectors table. 
It turns out that this issue is caused by the Antora Atlas extension. The connectors list is generated based on the latest version of components (this list is created by Antora at build-time), and this list also includes versions of components from the [prod site's manifest](https://docs.mulesoft.com/site-manifest.json). These imported versions are always set as the latest version, which is a problem because imported versions do not include the connector attributes we were keying off to generate the connectors list.

TLDR: Filtering out imported connector versions and setting the latest connector version to a local version fixed the issue. 

**Testing**

Tested to confirm that full builds of the prod and archive site display all versions.

