### PR TITLE
W-16007932  Update regex to match two or three digit numbers between "." in versions

### DIFF
--- a/src/helpers/release-notes.js
+++ b/src/helpers/release-notes.js
@@ -96,7 +96,7 @@ const cleanTitle = (title, version) => {
   if (title) {
     title = title.replace(/(Release Notes.*$)/, '').trim()
     if (version) {
-      title = title.replace(/(([0-9])+.([0-9a-z])+(.[0-9a-z])?$)/, '').trim()
+      title = title.replace(/(([0-9]{1,2})+.([0-9a-z]{1,2})+(.[0-9a-z]{1,3})?$)/, '').trim()
     }
   }
   return title

--- a/src/helpers/release-notes.js
+++ b/src/helpers/release-notes.js
@@ -78,9 +78,9 @@ const parseHTML = (html) => {
 const isVersion = (versionText) => {
   /* eslint-disable max-len */
   // https://confluence.internal.salesforce.com/pages/viewpage.action?spaceKey=MTDT&title=Use+the+Release+Notes+Templates
-  // examples: 1.0, 1.0.0, 2.11, 11.0, 4.x, 2.11.x
+  // examples: 1.0, 1.0.0, 2.11, 11.0, 4.x, 2.11.x, 2.4.30
   /* eslint-enable max-len */
-  return versionText.search('^([0-9])+.([0-9a-z])+(.[0-9])*$') > -1
+  return versionText.search('^([0-9])+.([0-9a-z]{1,3})+.([0-9a-z]{1,3})*$') > -1
 }
 
 const removeYear = (dateStr) => {
@@ -96,7 +96,7 @@ const cleanTitle = (title, version) => {
   if (title) {
     title = title.replace(/(Release Notes.*$)/, '').trim()
     if (version) {
-      title = title.replace(/(([0-9])+.([0-9a-z])+(.[0-9a-z])?$)/, '').trim()
+      title = title.replace(/(([0-9])+.([0-9a-z]{1,3})+.([0-9a-z]{1,3})?$)/, '').trim()
     }
   }
   return title

--- a/src/helpers/release-notes.js
+++ b/src/helpers/release-notes.js
@@ -96,7 +96,7 @@ const cleanTitle = (title, version) => {
   if (title) {
     title = title.replace(/(Release Notes.*$)/, '').trim()
     if (version) {
-      title = title.replace(/(([0-9]{1,2})+.([0-9a-z]{1,2})+(.[0-9a-z]{1,3})?$)/, '').trim()
+      title = title.replace(/(([0-9])+.([0-9a-z])+(.[0-9a-z])?$)/, '').trim()
     }
   }
   return title


### PR DESCRIPTION
[W-16007932] This change will make the version regex in cleanTitle() and isVersion() match versions up to 999 in the second and third places.
Currently having a two digit version in the last place causes the regex to not work as expected, for example:
API Manager version: 2.4.30