### PR TITLE
[W-16007932] fix latest release notes title

### DIFF
--- a/src/helpers/release-notes.js
+++ b/src/helpers/release-notes.js
@@ -3,6 +3,8 @@ const components = ['composer', 'release-notes']
 
 const duplicateMap = []
 
+const versionRegex = /([0-9])+\.([0-9a-z]{1,3})+(\.[0-9a-z]{1,3})*$/
+
 const getDatedReleaseNotesRawPages = (contentCatalog) => {
   return contentCatalog.getPages(({ asciidoc, out }) => {
     if (asciidoc && out) return getPagesWithDeploymentOptions(asciidoc)
@@ -78,9 +80,9 @@ const parseHTML = (html) => {
 const isVersion = (versionText) => {
   /* eslint-disable max-len */
   // https://confluence.internal.salesforce.com/pages/viewpage.action?spaceKey=MTDT&title=Use+the+Release+Notes+Templates
-  // examples: 1.0, 1.0.0, 2.11, 11.0, 4.x, 2.11.x
+  // examples: 1.0, 1.0.0, 2.11, 11.0, 4.x, 2.11.x, 2.4.30
   /* eslint-enable max-len */
-  return versionText.search('^([0-9])+.([0-9a-z])+(.[0-9])*$') > -1
+  return versionText.search(versionRegex) > -1
 }
 
 const removeYear = (dateStr) => {
@@ -93,13 +95,11 @@ const removeYear = (dateStr) => {
 }
 
 const cleanTitle = (title, version) => {
-  if (title) {
-    title = title.replace(/(Release Notes.*$)/, '').trim()
-    if (version) {
-      title = title.replace(/(([0-9])+.([0-9a-z])+(.[0-9a-z])?$)/, '').trim()
-    }
-  }
-  return title
+  if (!title) return ''
+
+  const cleanedTitle = title.replace(/(Release Notes.*$)/i, '').trim()
+
+  return version ? cleanedTitle.replace(versionRegex, '').trim() : cleanedTitle
 }
 
 module.exports = (numOfItems, { data }) => {


### PR DESCRIPTION
ref: [W-16007932](https://gus.lightning.force.com/a07EE00001uUqR0YAK)

fix the regex that captures the version in the release notes page title and headings:

before (see API Manager):
<img width="440" alt="Screenshot 2024-06-17 at 10 17 47 AM" src="https://github.com/mulesoft/docs-site-ui/assets/10934908/cb8b4a8f-960c-439c-a54d-941fe7a13b42">

after:
<img width="459" alt="Screenshot 2024-06-17 at 10 18 25 AM" src="https://github.com/mulesoft/docs-site-ui/assets/10934908/9a6bf855-b34a-4996-81de-5c24c00a294c">

### How to test

1. in docs-site-ui, run `npm run format:bundle` to export the build zip file
2. in docs-site-playbook, create a small playbook that only includes docs-general and docs-release-notes. Use the local build zip file (the file path to it) as the UI bundle 
3. perform a local build and open the local build landing page. It should show **API Manager 2.4.30** as one of the links in the Latest Releases section