### PR TITLE
[W-16115512] remove marketing header helmet

### DIFF
--- a/gulp.d/tasks/update.js
+++ b/gulp.d/tasks/update.js
@@ -17,7 +17,7 @@ module.exports = (partialsDir) => async () => {
 async function updateContent (partialsDir, component, contentType) {
   try {
     const urlParams = await getUrlParams(contentType)
-    const content = await fetch(`https://www.mulesoft.com/api/${component}?${urlParams}&docs-site`)
+    const content = await fetch(`https://www.mulesoft.com/api/${component}?${urlParams}&docs-site&no-helmet`)
     if (await isGoodStatus(content.status)) {
       const body = await content.json()
       if (await hasValidData(body)) {

--- a/src/partials/footer/footer-content-en.hbs
+++ b/src/partials/footer/footer-content-en.hbs
@@ -40,7 +40,7 @@
                       <li> <a href="https://developer.mulesoft.com/tutorials-and-howtos">Tutorials</a></li>
                       <li> <a href="https://docs.mulesoft.com/">Documentation</a></li>
                       <li> <a href="https://www.mulesoft.com/lp/ebook/api/integration-quick-start-guide">Quick start guides</a></li>
-                      <li> <a href="https://www.mulesoft.com/lp/contact/ask-an-expert">Ask an expert</a></li>
+                      <li> <a href="https://www.mulesoft.com/contact">Ask an expert</a></li>
                     </ul>
                   </li>
                   <li> <span>Resources</span>

--- a/src/partials/header/header-content-archive.hbs
+++ b/src/partials/header/header-content-archive.hbs
@@ -1,9 +1,6 @@
-<div class="ms-com-content ms-com-content-header br-nav updated-contact-pages closed new-nav with-helmet no-selector">
+<div class="ms-com-content ms-com-content-header br-nav updated-contact-pages closed new-nav no-helmet no-selector">
   <div class="lift-localized-promobanner">
     <div></div>
-  </div>
-  <div class="ms-com-helmet">
-    <div class="helmet-inside"> <a href="https://www.salesforce.com/" target="_blank" onclick="getGATracker().send('event', 'NAV', 'NavClick', 'Helmet - Salesforce link');"> <img src="https://www.mulesoft.com/sites/default/files/cmm_files/salesforce-logo.svg" alt="salesforce"> </a> <a href="https://www.salesforce.com/plus/experience/Dreamforce_2023/series/it_at_dreamforce_2023/episode/episode-s1e6" target="_blank" class="helmet-featured" onclick="getGATracker().send('event', 'NAV', 'NavClick', 'Helmet - Dreamforce registration');">Dreamforce On-Demand</a></div>
   </div>
   <header class="ms-com-header desktop-header">
     <div class="header-overlay"></div>

--- a/src/partials/header/header-content-en.hbs
+++ b/src/partials/header/header-content-en.hbs
@@ -1,9 +1,6 @@
-<div class="ms-com-content ms-com-content-header br-nav updated-contact-pages closed new-nav with-helmet ">
+<div class="ms-com-content ms-com-content-header br-nav updated-contact-pages closed new-nav no-helmet">
   <div class="lift-localized-promobanner">
     <div></div>
-  </div>
-  <div class="ms-com-helmet">
-    <div class="helmet-inside"> <a href="https://www.salesforce.com/" target="_blank" onclick="getGATracker().send('event', 'NAV', 'NavClick', 'Helmet - Salesforce link');"> <img src="https://www.mulesoft.com/sites/default/files/cmm_files/salesforce-logo.svg" alt="salesforce"> </a> <a href="https://www.salesforce.com/plus/experience/Dreamforce_2023/series/it_at_dreamforce_2023/episode/episode-s1e6" target="_blank" class="helmet-featured" onclick="getGATracker().send('event', 'NAV', 'NavClick', 'Helmet - Dreamforce registration');">Dreamforce On-Demand</a></div>
   </div>
   <header class="ms-com-header desktop-header">
     <div class="header-overlay"></div>

--- a/src/partials/header/header-content-jp.hbs
+++ b/src/partials/header/header-content-jp.hbs
@@ -1,4 +1,4 @@
-<div id="sl-ms-com-content-header" class="page-translated ms-com-content ms-com-content-tr ms-com-content-header updated-contact-pages new-nav new-selector br-nav loc-nav jp-nav ">
+<div id="sl-ms-com-content-header" class="page-translated ms-com-content ms-com-content-tr ms-com-content-header updated-contact-pages new-nav new-selector br-nav loc-nav jp-nav no-helmet">
   <div class="lift-localized-promobanner"></div>
   <header class="ms-com-header desktop-header">
     <div class="header-overlay"></div>


### PR DESCRIPTION
ref: [W-16115512](https://gus.lightning.force.com/a07EE00001vTKC8YAO)

remove the helmet from the marketing header.

before:
<img width="1159" alt="Screenshot 2024-06-27 at 12 39 09 PM" src="https://github.com/mulesoft/docs-site-ui/assets/10934908/c3b6e02e-16a3-4daa-b010-d0c0ec3c1127">

after:
<img width="1164" alt="Screenshot 2024-06-27 at 12 39 32 PM" src="https://github.com/mulesoft/docs-site-ui/assets/10934908/3d4c1dac-aafb-40f3-9398-04582eed4e1b">
