### PR TITLE
[W-15177355] Fix: Padding issue when collapsible blocks embedded in admonitions

### DIFF
--- a/preview-site-src/elements/miscellaneous.adoc
+++ b/preview-site-src/elements/miscellaneous.adoc
@@ -104,3 +104,15 @@ Log in to Anypoint Platform on your US or EU cloud host.
 * EU cloud (EU host): https://eu1.anypoint.mulesoft.com/login/[Anypoint Platform (EU)^]
 ====
 Some ending text
+
+=== Collapsible Block in an Admonition Block
+
+[NOTE]
+--
+When collapsible blocks are embedded in admonition blocks, the content should align to the inner block.
+
+.Collapsible Block Alignment Edge Case
+[%collapsible]
+====
+Previously, this content did not have any left padding.
+====

--- a/src/css/adoc/collapsible-blocks.css
+++ b/src/css/adoc/collapsible-blocks.css
@@ -13,7 +13,7 @@ details[open] > summary::after {
   transform: rotate(180deg);
 }
 
-details > .content {
+details > .content, .admonitionblock details > .content {
   padding: 12px 32px;
 }
 


### PR DESCRIPTION
Discovered one more edge case after rolling out the new collapsible block styles.

Issue:

![Screenshot 2024-08-29 at 10 18 22 AM](https://github.com/user-attachments/assets/fd753d89-d231-444b-bb8a-ea0760653b07)

Fix:

![Screenshot 2024-08-29 at 10 18 42 AM](https://github.com/user-attachments/assets/fb8e5b97-7954-4f20-9c8e-665be3b48ae4)
