### PR TITLE
[W-16618856] Reduce size of collapsible blocks

### DIFF
--- a/src/css/adoc/collapsible-blocks.css
+++ b/src/css/adoc/collapsible-blocks.css
@@ -14,7 +14,7 @@ details[open] > summary::after {
 }
 
 details > .content, .admonitionblock details > .content {
-  padding: 12px 32px;
+  padding: 6px 16px;
 }
 
 details + details {
@@ -37,13 +37,12 @@ summary {
   cursor: pointer;
   display: flex;
   font-family: var(--font-heading);
-  font-size: 20px;
   font-weight: var(--weight-medium);
   justify-content: space-between;
   letter-spacing: -0.08px;
   line-height: 28px;
   list-style: none;
-  padding: 12px 32px;
+  padding: 6px 16px;
 }
 
 summary::after {


### PR DESCRIPTION
Per the writing team, one of the main use cases for collapsible blocks is embedding in lists, and the new styles stand out too much.

We're reducing the size of collapsible blocks to fit the content better even if it's slightly inconsistent with Salesforce sizing.

Before and after:

![Screenshot 2024-08-29 at 11 53 31 AM](https://github.com/user-attachments/assets/5ec26452-cac8-4b37-a878-c4e88de2f298)

![Screenshot 2024-08-29 at 11 58 41 AM](https://github.com/user-attachments/assets/6450d631-654f-4fa7-9fe3-b85c3f08e0cd)
