### PR TITLE
[W-16646670] coveo migration

### DIFF
--- a/preview-site-src-jp/ui-model.yml
+++ b/preview-site-src-jp/ui-model.yml
@@ -27,6 +27,8 @@ site:
           - content: API ビルドの最初から最後まで
             url: /jp/general/api-led-overview.html
             items:
+              - content: ドキュメントの検索
+                url: /jp/general/search.html
               - content: ステップ 1. 前提条件
                 url: /jp/general/api-led-prerequisites.html
               - content: ステップ 2. API 仕様の設計

--- a/src/js/21-coveo-facets.js
+++ b/src/js/21-coveo-facets.js
@@ -22,7 +22,7 @@
       if (formattedVersions) {
         const versionFacet = document.createElement('atomic-facet')
         versionFacet.setAttribute('allowed-values', formattedVersions)
-        versionFacet.setAttribute('depends-on-product', componentDisplayName)
+        versionFacet.setAttribute('depends-on-mulesoftproduct', componentDisplayName)
         versionFacet.setAttribute('facet-id', `${componentID}-version`)
         versionFacet.setAttribute('field', 'mulesoftversionwithlatest')
         versionFacet.setAttribute('heading-level', 2)

--- a/src/layouts/home.hbs
+++ b/src/layouts/home.hbs
@@ -12,7 +12,6 @@
     <div class="flex container wrapper">
         {{> nav}}
         <main class="main" id="landing-page" data-ceiling="topbar">
-            {{> toolbar}}
             {{> notice-banner}}
             {{> landing-page}}
         </main>

--- a/src/partials/head/head-scripts.hbs
+++ b/src/partials/head/head-scripts.hbs
@@ -3,7 +3,7 @@
   {{> segment-script }}
 {{/if}}
 {{#if (or env.COVEO_API_KEY env.COVEO_API_KEY_JP)}}
-  {{> coveo-search-scripts org_id="mulesoftprodqzggq6re"}}
+  {{> coveo-search-scripts org_id="coveosalesforcetestakshatha"}}
   {{> coveo-ua-script org_id="mulesoftprodqzggq6re"}}
 {{/if}}
 {{#if (eq (site-profile) 'review' )}}

--- a/src/partials/head/head-scripts/coveo-ua-script.hbs
+++ b/src/partials/head/head-scripts/coveo-ua-script.hbs
@@ -6,7 +6,7 @@
       coveoua("send", "view", {
         contentIdKey: '@clickableUri',
         contentIdValue: `${window.location.origin}${window.location.pathname}`,
-        contentType: 'Docs',
+        contentType: 'mulesoft-docs',
         language: "{{#if (eq (site-profile) 'jp')}}ja{{else}}en{{/if}}",
         location: `${window.location.origin}${window.location.pathname}`
       });

--- a/src/partials/head/head-scripts/coveo-ua-script.hbs
+++ b/src/partials/head/head-scripts/coveo-ua-script.hbs
@@ -6,7 +6,7 @@
       coveoua("send", "view", {
         contentIdKey: '@clickableUri',
         contentIdValue: `${window.location.origin}${window.location.pathname}`,
-        contentType: 'mulesoft-docs',
+        contentType: 'Docs',
         language: "{{#if (eq (site-profile) 'jp')}}ja{{else}}en{{/if}}",
         location: `${window.location.origin}${window.location.pathname}`
       });

--- a/src/partials/nav.hbs
+++ b/src/partials/nav.hbs
@@ -2,7 +2,7 @@
   <span class="mobile-nav-focus-trapper"></span>
   {{#if (or preview (is-one-of (site-profile) 'prod' 'jp'))}}
   <div class="search">
-    <atomic-search-interface id="search" localization-compatibility-version="v4" {{#if (eq (site-profile) 'jp' )}}search-hub="Documentation-jp" language="ja"{{else}}search-hub="Documentation"{{/if}}>
+    <atomic-search-interface id="search" localization-compatibility-version="v4" {{#if (eq (site-profile) 'jp' )}}search-hub="mulesoft-docs-jp" language="ja"{{else}}search-hub="mulesoft-docs"{{/if}}>
       <atomic-search-layout>
           <atomic-layout-section section="search">
               <atomic-search-box redirection-url="{{relativize site.url}}/general/search{{#if preview}}.html{{/if}}">

--- a/src/partials/search/search-interface.hbs
+++ b/src/partials/search/search-interface.hbs
@@ -2,11 +2,11 @@
 <div class="search-div">
   <atomic-aria-live></atomic-aria-live>
   <atomic-search-interface id="search" localization-compatibility-version="v4"
-    fields-to-include='["mulesoftislatestversion", "mulesoftproductversion", "mulesoftversionmajor", "mulesoftversionminor", "mulesoftversionpatch", "mulesoftversionwithlatest", "product", "version"]'
-    {{#if (eq (site-profile) 'jp' )}}search-hub="Documentation-jp" language="ja"{{else}}search-hub="Documentation"{{/if}}>
+    fields-to-include='["mulesoftislatestversion", "mulesoftproduct", "mulesoftproductversion", "mulesoftversion", "mulesoftversionmajor", "mulesoftversionminor", "mulesoftversionpatch", "mulesoftversionwithlatest"]'
+    {{#if (eq (site-profile) 'jp' )}}search-hub="mulesoft-docs-jp" language="ja"{{else}}search-hub="mulesoft-docs"{{/if}}>
     <atomic-search-layout>
       <atomic-layout-section section="facets">
-      <atomic-facet facet-id="product" field="product" heading-level=2 label="{{#if (eq (site-profile) 'jp')}}製品別に絞り込み{{else}}Filter by Product{{/if}}"></atomic-facet>
+      <atomic-facet facet-id="mulesoftproduct" field="mulesoftproduct" heading-level=2 label="{{#if (eq (site-profile) 'jp')}}製品別に絞り込み{{else}}Filter by Product{{/if}}"></atomic-facet>
       </atomic-layout-section>
       <atomic-layout-section section="main">
         <atomic-layout-section section="status">

--- a/src/partials/search/search-result-template.hbs
+++ b/src/partials/search/search-result-template.hbs
@@ -58,11 +58,11 @@
     </atomic-result-section-excerpt>
     <atomic-result-section-bottom-metadata>
       <atomic-result-fields-list>
-        <atomic-field-condition class="field" if-defined="product">
-          <atomic-result-text field="product"></atomic-result-text>
+        <atomic-field-condition class="field" if-defined="mulesoftproduct">
+          <atomic-result-text field="mulesoftproduct"></atomic-result-text>
         </atomic-field-condition>
-        <atomic-field-condition class="field" if-defined="version">
-          <atomic-result-text field="version"></atomic-result-text>
+        <atomic-field-condition class="field" if-defined="mulesoftversion">
+          <atomic-result-text field="mulesoftversion"></atomic-result-text>
         </atomic-field-condition>
         <atomic-field-condition class="field" if-defined="mulesoftislatestversion">
           <atomic-result-badge label="{{#if (eq (site-profile) 'jp')}}最新{{else}}latest version{{/if}}"></atomic-result-badge>


### PR DESCRIPTION
ref: W-16646670

Moving Coveo search from the mulesoft org to the salesforce org (dev). Most of the work is renaming fields and changing the org. 

Coveo User Analytics (UA) is not in scope, so there are no changes in the UA scripts until after the moratorium ends.

### How to test

In 1password, search for **coveo token**. Copy the dev secrets for EN and JP site and export them as these variables (I have these added to my .zshrc file for convenience):

```sh
export COVEO_API_KEY=xx13....
export COVEO_API_KEY_JP=xx8...
```

Then run `npm run preview` and perform a search (example: http://localhost:8080/general/search.html#f-mulesoftproduct=Connector%20DevKit). Note that the local preview site doesn't have all the products and versions so most of the version facets (the ones that appear when you select a product) don't work. One product that works is **Connector DevKit** if you want to validate the version facets:

<img width="1362" alt="Screenshot 2024-09-10 at 7 23 06 AM" src="https://github.com/user-attachments/assets/1a25e390-b8df-4d87-81ba-38d223096b8a">

You can also run `npm run preview-jp` then go to http://localhost:8080/jp/general/search.html#f-mulesoftproduct=Connector%20DevKit to check on the JP results.