### PR TITLE
[W-16084826] create PR in playbook main branch only

### DIFF
--- a/gulp.d/tasks/release.js
+++ b/gulp.d/tasks/release.js
@@ -58,7 +58,7 @@ const createNewBranch = async ({ octokit, owner, repo }, ref, newBranchName) => 
   }
 }
 
-const createPR = async ({ octokit, owner, repo }, tagName, ref, sites, secretKey, passphrase) => {
+const createPR = async ({ octokit, owner, repo, tagName, ref, sites, secretKey, passphrase }) => {
   console.log(`submitting PR to the ${repo} repo...`)
   const newBranchName = tagName
   await createNewBranch({ octokit, owner, repo }, ref, newBranchName)
@@ -402,12 +402,16 @@ module.exports = (dest, bundleName, owner, repo, token, secretKey, passphrase, u
     await updateRelease(githubConfig, 'latest', bundleName, bundlePath)
     if (secretKey) {
       await createPR(
-        { octokit, owner, repo: 'docs-site-playbook' },
-        tagName,
-        defaultBranch,
-        ['archive', 'en', 'jp'],
-        secretKey,
-        passphrase
+        {
+          octokit,
+          owner,
+          repo: 'docs-site-playbook',
+          tagName,
+          defaultBranch,
+          sites: ['archive', 'en', 'jp'],
+          secretKey,
+          passphrase,
+        }
       )
     } else {
       console.log('Secret key is not found, skipping PRs creation in the playbook repo.')

--- a/gulp.d/tasks/release.js
+++ b/gulp.d/tasks/release.js
@@ -59,7 +59,7 @@ const createNewBranch = async ({ octokit, owner, repo }, ref, newBranchName) => 
   }
 }
 
-const createPR = async ({ octokit, owner, repo }, tagName, ref, filePath, secretKey, passphrase) => {
+const createPR = async ({ octokit, owner, repo, tagName, ref, filePath, secretKey, passphrase}) => {
   console.log(`submitting PR to the ${repo} repo, ${ref} branch...`)
   const newBranchName = `${tagName}-for-${ref}`
   await createNewBranch({ octokit, owner, repo }, ref, newBranchName)
@@ -412,12 +412,16 @@ module.exports = (dest, bundleName, owner, repo, token, secretKey, passphrase, u
     if (secretKey) {
       for (const ref of baseBranches) {
         await createPR(
-          { octokit, owner, repo: 'docs-site-playbook' },
-          tagName,
-          ref,
-          'antora-playbook.yml',
-          secretKey,
-          passphrase
+          {
+            octokit,
+            owner,
+            repo: 'docs-site-playbook',
+            tagName,
+            ref,
+            filePath: 'antora-playbook.yml',
+            secretKey,
+            passphrase,
+          }
         )
       }
     } else {


### PR DESCRIPTION
ref: W-16084826

After a PR merge, instead of creating 3 separate PRs in docs-site-playbook, this now creates only 1 PR in the main branch to update all 3 playbooks there. Validated by running the script locally to create https://github.com/mulesoft/docs-site-playbook/pull/2677

Also did a little bit of clean up.