### PR TITLE
[W-15061326] atomic library upgrade 2 -> 3

### DIFF
--- a/src/css/vendor/coveo.css
+++ b/src/css/vendor/coveo.css
@@ -45,6 +45,8 @@
 }
 
 atomic-external {
+  height: 40px;
+
   @media (min-width: 1024px) {
     grid-area: atomic-external;
     width: 80%;
@@ -142,7 +144,7 @@ atomic-results-per-page::part(label) {
 }
 
 nav atomic-search-box {
-  &::part(input) {
+  &::part(textarea) {
     font-size: var(--atomic-text-sm);
     padding-left: 2.5em;
   }
@@ -155,35 +157,19 @@ nav atomic-search-box {
 }
 
 atomic-search-box {
+  &::part(textarea-spacer) {
+    height: 40px;
+  }
+
   &::part(wrapper) {
     border-color: #909aa3;
     border-radius: var(--radius);
     height: 40px;
     margin-left: -4px;
-
-    &:focus-within {
-      --tw-ring-color: none;
-    }
-
-    & div {
-      padding-left: 40px;
-    }
   }
 
-  &::part(input) {
-    &::placeholder,
-    &:-ms-input-placeholder, /* Internet Explorer 10-11 */
-    &::-ms-input-placeholder {
-      /* Microsoft Edge */
-      color: var(--eyebrow-gray);
-      opacity: 1; /* Firefox */
-    }
-
-    &:active,
-    &:focus {
-      border: 1px solid var(--sds-g-color-blue-30);
-      box-shadow: 0 0 0 3px #00a2df40;
-    }
+  &::part(textarea) {
+    padding: 8px;
   }
 
   &::part(suggestions-wrapper) {
@@ -193,21 +179,9 @@ atomic-search-box {
   }
 
   &::part(submit-button) {
-    border-radius: 0 var(--radius) var(--radius) 0;
-    display: inline-flex;
-    height: 40px;
-    width: fit-content;
-
-    &:active,
-    &:focus {
-      background-color: var(--sds-g-color-blue-30);
-      border: 1px solid var(--sds-g-color-blue-30);
-      box-shadow: 0 0 0 3px #00a2df40;
+    &:hover {
+      background-color: var(--atomic-primary-light) !important;
     }
-  }
-
-  &::part(submit-icon) {
-    margin: auto 12px;
   }
 }
 

--- a/src/css/vendor/coveo.css
+++ b/src/css/vendor/coveo.css
@@ -178,11 +178,30 @@ atomic-search-box {
     box-shadow: 0 2px 3px #00000029;
   }
 
-  &::part(submit-button) {
-    &:hover {
-      background-color: var(--atomic-primary-light) !important;
-    }
+  &::part(submit-button-wrapper) {
+    margin: 0;
   }
+
+  &::part(submit-button) {
+    background-color: var(--atomic-primary);
+    border-radius: 0 var(--radius) var(--radius) 0;
+    color: var(--atomic-on-primary);
+    display: inline-flex;
+    height: 40px;
+    width: 40px;
+  }
+}
+
+/* for some reason, the active/focus/hover states for this need to be stated separately from the atomic-search-box block for them to work. */
+atomic-search-box::part(submit-button):active,
+atomic-search-box::part(submit-button):focus {
+  background-color: var(--sds-g-color-blue-30);
+  border: 1px solid var(--sds-g-color-blue-30);
+  box-shadow: 0 0 0 3px #00a2df40;
+}
+
+atomic-search-box::part(submit-button):hover {
+  background-color: var(--atomic-primary-light);
 }
 
 atomic-smart-snippet::part(smart-snippet),

--- a/src/js/25-trending-topics-fallback.js
+++ b/src/js/25-trending-topics-fallback.js
@@ -11,7 +11,7 @@
   }
 
   const hasValidRecommendations = (recsListShadowRoot) => {
-    if (recsListShadowRoot.childElementCount === 0) return false
+    if (recsListShadowRoot.childElementCount === 0 || recsListShadowRoot.querySelector('h2') == null) return false
     const atomicRecsResult = recsListShadowRoot.querySelector('atomic-recs-result')
     if (atomicRecsResult) {
       const recsResultShadowRoot = atomicRecsResult.shadowRoot

--- a/src/js/vendor/coveo.bundle.js
+++ b/src/js/vendor/coveo.bundle.js
@@ -54,10 +54,10 @@
   const isMobileBrowser = () => /Android|iPhone|iPad/i.test(navigator.userAgent)
 
   class Searchbox {
-    constructor (atomicSearchbox, searchboxShadowRoot, searchboxInput) {
+    constructor (atomicSearchbox, searchboxShadowRoot, searchboxTextarea) {
       this.atomicSearchbox = atomicSearchbox
       this.searchboxShadowRoot = searchboxShadowRoot
-      this.searchboxInput = searchboxInput
+      this.searchboxTextarea = searchboxTextarea
       this.searchboxDiv = searchboxShadowRoot.querySelector('div')
       this.searchboxSubmitButton = searchboxShadowRoot.querySelector('button[part="submit-button"]')
 
@@ -67,7 +67,7 @@
     updateAriaLabelForInput () {
       // .getAttribute('aria-label') is used here instead of .ariaLabel
       // because for some reason, it returned an error in firefox
-      this.searchboxInput.ariaLabel = `${this.searchboxInput.getAttribute('aria-label')} For shortcut to search, \
+      this.searchboxTextarea.ariaLabel = `${this.searchboxTextarea.getAttribute('aria-label')} For shortcut to search, \
 use ${osMap[this.clientOS].secondaryKeyLabelLong} + ${shortcutKeyMap.keyLabel}`
     }
 
@@ -93,8 +93,8 @@ use ${osMap[this.clientOS].secondaryKeyLabelLong} + ${shortcutKeyMap.keyLabel}`
     }
 
     appendKeyboardShortcut () {
-      if (this.searchboxInput) {
-        this.searchboxInput.placeholder = `${this.searchboxInput.placeholder} (${
+      if (this.searchboxTextarea) {
+        this.searchboxTextarea.placeholder = `${this.searchboxTextarea.placeholder} (${
           osMap[this.clientOS].secondaryKeyLabel
         } + ${shortcutKeyMap.keyLabel})`
       }
@@ -106,7 +106,7 @@ use ${osMap[this.clientOS].secondaryKeyLabelLong} + ${shortcutKeyMap.keyLabel}`
       document.onkeyup = document.onkeydown = (e) => {
         const key = e.which || e.keyCode
         if (e[osMap[this.clientOS].secondaryKey] && key === shortcutKeyMap.keyCode) {
-          if (this.searchboxInput) this.searchboxInput.focus()
+          if (this.searchboxTextarea) this.searchboxTextarea.focus()
           e.preventDefault()
         }
       }
@@ -122,7 +122,7 @@ use ${osMap[this.clientOS].secondaryKeyLabelLong} + ${shortcutKeyMap.keyLabel}`
       this.searchboxDiv.insertBefore(img, this.searchboxDiv.firstChild)
     }
 
-    addSearchboxInputEventListeners () {
+    addsearchboxTextareaEventListeners () {
       //// save this block in case we need to add the kbd element back
       // const focusableElements = this.searchboxDiv.querySelectorAll('a, button, input')
       // focusableElements.forEach((focusableElement) => {
@@ -134,8 +134,8 @@ use ${osMap[this.clientOS].secondaryKeyLabelLong} + ${shortcutKeyMap.keyLabel}`
       //     e.preventDefault()
       //   })
       // })
-      this.searchboxInput.addEventListener('input', (e) => this.toggleSubmitText(e))
-      this.searchboxInput.addEventListener('blur', (e) => this.toggleSubmitText(e))
+      this.searchboxTextarea.addEventListener('input', (e) => this.toggleSubmitText(e))
+      this.searchboxTextarea.addEventListener('blur', (e) => this.toggleSubmitText(e))
       setTimeout(() => this.toggleSubmitText(), 500)
     }
 
@@ -145,11 +145,11 @@ use ${osMap[this.clientOS].secondaryKeyLabelLong} + ${shortcutKeyMap.keyLabel}`
     }
 
     toggleSubmitButtonDisabled (e, force) {
-      if (this.searchboxInput) {
+      if (this.searchboxTextarea) {
         if (force) {
           this.atomicSearchbox.setAttribute('disable-search', force)
         } else {
-          this.atomicSearchbox.setAttribute('disable-search', this.searchboxInput.value.length === 0)
+          this.atomicSearchbox.setAttribute('disable-search', this.searchboxTextarea.value.length === 0)
         }
       }
       if (e) e.preventDefault()
@@ -158,10 +158,10 @@ use ${osMap[this.clientOS].secondaryKeyLabelLong} + ${shortcutKeyMap.keyLabel}`
     toggleSubmitText (e) {
       const submitText = this.searchboxSubmitButton.querySelector('p')
       if (submitText) {
-        submitText.style.display = this.searchboxInput.value ? 'inherit' : 'none'
-        submitText.style.margin = this.searchboxInput.value ? 'auto 10px auto -5px' : 'auto 10px auto 0'
+        submitText.style.display = this.searchboxTextarea.value ? 'inherit' : 'none'
+        submitText.style.margin = this.searchboxTextarea.value ? 'auto 10px auto -5px' : 'auto 10px auto 0'
       }
-      if (this.searchboxInput.value) {
+      if (this.searchboxTextarea.value) {
         const clearButton = this.searchboxDiv.querySelector('button[part="clear-button"]')
         if (clearButton) {
           if (clearButton.getAttribute('listener') !== 'true') {
@@ -177,12 +177,14 @@ use ${osMap[this.clientOS].secondaryKeyLabelLong} + ${shortcutKeyMap.keyLabel}`
     }
 
     updateInput () {
-      if (this.searchboxInput) {
+      if (this.searchboxTextarea) {
         if (document.documentElement.lang === 'en') {
-          this.searchboxInput.placeholder = 'Search Docs'
+          this.searchboxTextarea.placeholder = 'Search Docs'
           // .getAttribute('aria-label') is used here instead of .ariaLabel
           // because for some reason, it returned an error in firefox
-          this.searchboxInput.ariaLabel = this.searchboxInput
+          console.log(this.searchboxTextarea)
+          console.log(this.searchboxTextarea.getAttribute('aria-label'))
+          this.searchboxTextarea.ariaLabel = this.searchboxTextarea
             .getAttribute('aria-label')
             .replace('Search field', 'Search Doc field')
           if (this.searchboxDiv) {
@@ -199,7 +201,7 @@ use ${osMap[this.clientOS].secondaryKeyLabelLong} + ${shortcutKeyMap.keyLabel}`
           }
         }
         this.addLeftSearchIcon()
-        this.addSearchboxInputEventListeners()
+        this.addsearchboxTextareaEventListeners()
       }
     }
 
@@ -224,9 +226,9 @@ use ${osMap[this.clientOS].secondaryKeyLabelLong} + ${shortcutKeyMap.keyLabel}`
       const atomicSearchbox = document.querySelector('atomic-search-box')
       const searchboxShadowRoot = atomicSearchbox && atomicSearchbox.shadowRoot
       if (searchboxShadowRoot) {
-        const searchboxInput = searchboxShadowRoot.querySelector('input')
-        if (searchboxInput) {
-          const searchbox = new Searchbox(atomicSearchbox, searchboxShadowRoot, searchboxInput)
+        const searchboxTextarea = searchboxShadowRoot.querySelector('textarea[part="textarea"]')
+        if (searchboxTextarea) {
+          const searchbox = new Searchbox(atomicSearchbox, searchboxShadowRoot, searchboxTextarea)
           try {
             searchbox.makeMoreAssistive()
             clearInterval(updateSearchbox)

--- a/src/partials/head/head-scripts/coveo-search-scripts.hbs
+++ b/src/partials/head/head-scripts/coveo-search-scripts.hbs
@@ -13,7 +13,6 @@
         await searchInterface.initialize({
           accessToken,
           organizationId,
-          analytics: {analyticsMode: 'legacy'},
         });
         if (window.location.href.includes('/search')) searchInterface.executeFirstSearch();
       }

--- a/src/partials/head/head-scripts/coveo-search-scripts.hbs
+++ b/src/partials/head/head-scripts/coveo-search-scripts.hbs
@@ -1,7 +1,7 @@
 <script
   type="module"
-  src="https://static.cloud.coveo.com/atomic/v2.78.1/atomic.esm.js"
-  integrity="sha512-OgBW+DXnwraEnF880Ejou/WPdroRMyauAbnGwm7oqY0GClQELEm8XPMvwIo/lJsau610xPfaKTdhjyIBTr1jEA=="
+  src="https://static.cloud.coveo.com/atomic/v3.7.0/atomic.esm.js"
+  integrity="sha512-fLs7ot1PpQgZRoHpoVrxF2zWq6OZsKE7uaZYVmiTnmwTUIehgr/nvfNhqcbPP0PWfy81tEBxMcXJe8H67sA1Pg=="
   crossorigin="anonymous">
 </script>
 <script nonce="**CSP_NONCE**">
@@ -10,11 +10,10 @@
       await customElements.whenDefined("atomic-search-interface");
       const searchInterface = document.querySelector("#search");
       if (searchInterface) {
-        const organizationEndpoints = await searchInterface.getOrganizationEndpoints(organizationId)
         await searchInterface.initialize({
           accessToken,
           organizationId,
-          organizationEndpoints,
+          analytics: {analyticsMode: 'legacy'},
         });
         if (window.location.href.includes('/search')) searchInterface.executeFirstSearch();
       }

--- a/src/partials/header/header-content-archive.hbs
+++ b/src/partials/header/header-content-archive.hbs
@@ -43,7 +43,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4> <span class="mega-menu-item-footer-featured-content">Gartner names MuleSoft a Leader</span></h4>
+                          <p> <span class="mega-menu-item-footer-featured-content">Gartner names MuleSoft a Leader</span></p>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">Read reports</span></div>
                         </div>
                       </a></div>
@@ -82,7 +82,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4> <span class="mega-menu-item-footer-featured-content">Create connected experiences with AI</span></h4>
+                          <p> <span class="mega-menu-item-footer-featured-content">Create connected experiences with AI</span></p>
                           <p class="content-link"></p>
                           <div class="mega-menu-item-footer-featured-content"> Learn the critical steps to developing an AI strategy and foundation.</div>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">Read more</span></div>
@@ -117,7 +117,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4> <span class="mega-menu-item-footer-featured-content">Future of connected AI agents</span></h4>
+                          <p> <span class="mega-menu-item-footer-featured-content">Future of connected AI agents</span></p>
                           <p class="content-link"></p>
                           <div class="mega-menu-item-footer-featured-content">Discover how to prepare for the future of autonomous AI agents.</div>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">Read more</span></div>
@@ -157,7 +157,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4> <span class="mega-menu-item-footer-featured-content"> The world of AI is a world of APIs </span></h4>
+                          <p> <span class="mega-menu-item-footer-featured-content"> The world of AI is a world of APIs </span></p>
                           <p class="content-link"></p>
                           <div class="mega-menu-item-footer-featured-content">Relive the best moments from Connect:AI with 20+ on-demand sessions.</div>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">Start watching</span></div>
@@ -271,7 +271,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4> <span class="mega-menu-item-footer-featured-content">Gartner names MuleSoft a Leader</span></h4>
+                          <p> <span class="mega-menu-item-footer-featured-content">Gartner names MuleSoft a Leader</span></p>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">Read reports</span></div>
                         </div>
                       </a></div>
@@ -310,7 +310,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4> <span class="mega-menu-item-footer-featured-content">Create connected experiences with AI</span></h4>
+                          <p> <span class="mega-menu-item-footer-featured-content">Create connected experiences with AI</span></p>
                           <p class="content-link"></p>
                           <div class="mega-menu-item-footer-featured-content"> Learn the critical steps to developing an AI strategy and foundation.</div>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">Read more</span></div>
@@ -345,7 +345,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4> <span class="mega-menu-item-footer-featured-content">Future of connected AI agents</span></h4>
+                          <p> <span class="mega-menu-item-footer-featured-content">Future of connected AI agents</span></p>
                           <p class="content-link"></p>
                           <div class="mega-menu-item-footer-featured-content">Discover how to prepare for the future of autonomous AI agents.</div>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">Read more</span></div>
@@ -385,7 +385,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4> <span class="mega-menu-item-footer-featured-content"> The world of AI is a world of APIs </span></h4>
+                          <p> <span class="mega-menu-item-footer-featured-content"> The world of AI is a world of APIs </span></p>
                           <p class="content-link"></p>
                           <div class="mega-menu-item-footer-featured-content">Relive the best moments from Connect:AI with 20+ on-demand sessions.</div>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">Start watching</span></div>

--- a/src/partials/header/header-content-en.hbs
+++ b/src/partials/header/header-content-en.hbs
@@ -43,7 +43,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4> <span class="mega-menu-item-footer-featured-content">Gartner names MuleSoft a Leader</span></h4>
+                          <p> <span class="mega-menu-item-footer-featured-content">Gartner names MuleSoft a Leader</span></p>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">Read reports</span></div>
                         </div>
                       </a></div>
@@ -82,7 +82,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4> <span class="mega-menu-item-footer-featured-content">Create connected experiences with AI</span></h4>
+                          <p> <span class="mega-menu-item-footer-featured-content">Create connected experiences with AI</span></p>
                           <p class="content-link"></p>
                           <div class="mega-menu-item-footer-featured-content"> Learn the critical steps to developing an AI strategy and foundation.</div>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">Read more</span></div>
@@ -117,7 +117,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4> <span class="mega-menu-item-footer-featured-content">Future of connected AI agents</span></h4>
+                          <p> <span class="mega-menu-item-footer-featured-content">Future of connected AI agents</span></p>
                           <p class="content-link"></p>
                           <div class="mega-menu-item-footer-featured-content">Discover how to prepare for the future of autonomous AI agents.</div>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">Read more</span></div>
@@ -157,7 +157,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4> <span class="mega-menu-item-footer-featured-content"> The world of AI is a world of APIs </span></h4>
+                          <p> <span class="mega-menu-item-footer-featured-content"> The world of AI is a world of APIs </span></p>
                           <p class="content-link"></p>
                           <div class="mega-menu-item-footer-featured-content">Relive the best moments from Connect:AI with 20+ on-demand sessions.</div>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">Start watching</span></div>
@@ -287,7 +287,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4> <span class="mega-menu-item-footer-featured-content">Gartner names MuleSoft a Leader</span></h4>
+                          <p> <span class="mega-menu-item-footer-featured-content">Gartner names MuleSoft a Leader</span></p>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">Read reports</span></div>
                         </div>
                       </a></div>
@@ -326,7 +326,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4> <span class="mega-menu-item-footer-featured-content">Create connected experiences with AI</span></h4>
+                          <p> <span class="mega-menu-item-footer-featured-content">Create connected experiences with AI</span></p>
                           <p class="content-link"></p>
                           <div class="mega-menu-item-footer-featured-content"> Learn the critical steps to developing an AI strategy and foundation.</div>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">Read more</span></div>
@@ -361,7 +361,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4> <span class="mega-menu-item-footer-featured-content">Future of connected AI agents</span></h4>
+                          <p> <span class="mega-menu-item-footer-featured-content">Future of connected AI agents</span></p>
                           <p class="content-link"></p>
                           <div class="mega-menu-item-footer-featured-content">Discover how to prepare for the future of autonomous AI agents.</div>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">Read more</span></div>
@@ -401,7 +401,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4> <span class="mega-menu-item-footer-featured-content"> The world of AI is a world of APIs </span></h4>
+                          <p> <span class="mega-menu-item-footer-featured-content"> The world of AI is a world of APIs </span></p>
                           <p class="content-link"></p>
                           <div class="mega-menu-item-footer-featured-content">Relive the best moments from Connect:AI with 20+ on-demand sessions.</div>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">Start watching</span></div>

--- a/src/partials/header/header-content-jp.hbs
+++ b/src/partials/header/header-content-jp.hbs
@@ -44,9 +44,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4>
-                            <div class="mega-menu-item-footer-featured-content">&#12460;&#12540;&#12488;&#12490;&#12540;&#12364; MuleSoft &#12434;&#12522;&#12540;&#12480;&#12540;&#12392;&#12375;&#12390;&#35413;&#20385;</div>
-                          </h4>
+                          <p> <span class="mega-menu-item-footer-featured-content">&#12460;&#12540;&#12488;&#12490;&#12540;&#12364; MuleSoft &#12434;&#12522;&#12540;&#12480;&#12540;&#12392;&#12375;&#12390;&#35413;&#20385;</span></p>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">&#12480;&#12454;&#12531;&#12525;&#12540;&#12489;&#12377;&#12427;</span></div>
                         </div>
                       </a></div>
@@ -83,9 +81,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4>
-                            <div class="mega-menu-item-footer-featured-content">Salesforce &#12398;&#12501;&#12523;&#12497;&#12527;&#12540;&#12434;&#35299;&#25918;&#12377;&#12427; API &#27963;&#29992;&#34899;</div>
-                          </h4>
+                          <p> <span class="mega-menu-item-footer-featured-content">Salesforce &#12398;&#12501;&#12523;&#12497;&#12527;&#12540;&#12434;&#35299;&#25918;&#12377;&#12427; API &#27963;&#29992;&#34899;</span></p>
                           <p class="content-link"></p>
                           <div class="mega-menu-item-footer-featured-content"> Salesforce Customer 360&#12392;&#12398;&#36899;&#25658;&#12391;&#12499;&#12472;&#12493;&#12473;&#12398;&#12487;&#12472;&#12479;&#12523;&#22793;&#38761;&#12434;&#23455;&#29694;</div>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">eBook&#12434;&#35501;&#12416;</span></div>
@@ -119,9 +115,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4>
-                            <div class="mega-menu-item-footer-featured-content">Anypoint Platform&#65306;&#38283;&#30330;&#22522;&#30990; (&#28961;&#26009;)</div>
-                          </h4>
+                          <p> <span class="mega-menu-item-footer-featured-content">Anypoint Platform&#65306;&#38283;&#30330;&#22522;&#30990; (&#28961;&#26009;)</span></p>
                           <p class="content-link"></p>
                           <div class="mega-menu-item-footer-featured-content"> Anypoint Platform &#12434;&#20351;&#12387;&#12390;&#12289;API &#12398;&#38283;&#30330;&#12392;&#12452;&#12531;&#12486;&#12464;&#12524;&#12540;&#12471;&#12519;&#12531;&#12398;&#22522;&#30990;&#12434;&#23398;&#12406;&#12383;&#12417;&#12398;&#12467;&#12540;&#12473;</div>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">&#28961;&#26009;&#12391;&#21463;&#35611;&#12377;&#12427;</span></div>
@@ -159,9 +153,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4>
-                            <div class="mega-menu-item-footer-featured-content"> MuleSoft Forum Japan</div>
-                          </h4>
+                          <p> <span class="mega-menu-item-footer-featured-content"> MuleSoft Forum Japan </span></p>
                           <p class="content-link"></p>
                           <div class="mega-menu-item-footer-featured-content notranslate"> &#12458;&#12531;&#12487;&#12510;&#12531;&#12489;&#37197;&#20449;&#20013;<br>Aflac&#12420;&#23500;&#22763;&#36890;&#12289;&#12509;&#12522;&#12503;&#12521;&#12473;&#12481;&#12483;&#12463;&#12473;&#12364;&#25512;&#36914;&#12375;&#12390;&#12356;&#12427;DX&#12398;&#20107;&#20363;&#12434;&#35222;&#32884;&#12375;&#12414;&#12379;&#12435;&#12363;&#65311;</div>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">&#35222;&#32884;&#12377;&#12427;</span></div>
@@ -292,9 +284,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4>
-                            <div class="mega-menu-item-footer-featured-content">&#12460;&#12540;&#12488;&#12490;&#12540;&#12364; MuleSoft &#12434;&#12522;&#12540;&#12480;&#12540;&#12392;&#12375;&#12390;&#35413;&#20385;</div>
-                          </h4>
+                          <p> <span class="mega-menu-item-footer-featured-content">&#12460;&#12540;&#12488;&#12490;&#12540;&#12364; MuleSoft &#12434;&#12522;&#12540;&#12480;&#12540;&#12392;&#12375;&#12390;&#35413;&#20385;</span></p>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">&#12480;&#12454;&#12531;&#12525;&#12540;&#12489;&#12377;&#12427;</span></div>
                         </div>
                       </a></div>
@@ -331,9 +321,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4>
-                            <div class="mega-menu-item-footer-featured-content">Salesforce &#12398;&#12501;&#12523;&#12497;&#12527;&#12540;&#12434;&#35299;&#25918;&#12377;&#12427; API &#27963;&#29992;&#34899;</div>
-                          </h4>
+                          <p> <span class="mega-menu-item-footer-featured-content">Salesforce &#12398;&#12501;&#12523;&#12497;&#12527;&#12540;&#12434;&#35299;&#25918;&#12377;&#12427; API &#27963;&#29992;&#34899;</span></p>
                           <p class="content-link"></p>
                           <div class="mega-menu-item-footer-featured-content"> Salesforce Customer 360&#12392;&#12398;&#36899;&#25658;&#12391;&#12499;&#12472;&#12493;&#12473;&#12398;&#12487;&#12472;&#12479;&#12523;&#22793;&#38761;&#12434;&#23455;&#29694;</div>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">eBook&#12434;&#35501;&#12416;</span></div>
@@ -367,9 +355,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4>
-                            <div class="mega-menu-item-footer-featured-content">Anypoint Platform&#65306;&#38283;&#30330;&#22522;&#30990; (&#28961;&#26009;)</div>
-                          </h4>
+                          <p> <span class="mega-menu-item-footer-featured-content">Anypoint Platform&#65306;&#38283;&#30330;&#22522;&#30990; (&#28961;&#26009;)</span></p>
                           <p class="content-link"></p>
                           <div class="mega-menu-item-footer-featured-content"> Anypoint Platform &#12434;&#20351;&#12387;&#12390;&#12289;API &#12398;&#38283;&#30330;&#12392;&#12452;&#12531;&#12486;&#12464;&#12524;&#12540;&#12471;&#12519;&#12531;&#12398;&#22522;&#30990;&#12434;&#23398;&#12406;&#12383;&#12417;&#12398;&#12467;&#12540;&#12473;</div>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">&#28961;&#26009;&#12391;&#21463;&#35611;&#12377;&#12427;</span></div>
@@ -407,9 +393,7 @@
                           </div>
                         </div>
                         <div class="featured-right-content">
-                          <h4>
-                            <div class="mega-menu-item-footer-featured-content"> MuleSoft Forum Japan</div>
-                          </h4>
+                          <p> <span class="mega-menu-item-footer-featured-content"> MuleSoft Forum Japan </span></p>
                           <p class="content-link"></p>
                           <div class="mega-menu-item-footer-featured-content notranslate"> &#12458;&#12531;&#12487;&#12510;&#12531;&#12489;&#37197;&#20449;&#20013;<br>Aflac&#12420;&#23500;&#22763;&#36890;&#12289;&#12509;&#12522;&#12503;&#12521;&#12473;&#12481;&#12483;&#12463;&#12473;&#12364;&#25512;&#36914;&#12375;&#12390;&#12356;&#12427;DX&#12398;&#20107;&#20363;&#12434;&#35222;&#32884;&#12375;&#12414;&#12379;&#12435;&#12363;&#65311;</div>
                           <div class="mega-menu-item-footer-featured-content"> <span class="arrow-link">&#35222;&#32884;&#12377;&#12427;</span></div>

--- a/src/partials/search/search-interface.hbs
+++ b/src/partials/search/search-interface.hbs
@@ -1,8 +1,7 @@
 {{#if (or env.COVEO_API_KEY env.COVEO_API_KEY_JP)}}
 <div class="search-div">
   <atomic-aria-live></atomic-aria-live>
-  <atomic-search-interface id="search" localization-compatibility-version="v4"
-    fields-to-include='["mulesoftcleantitle", "mulesoftislatestversion", "mulesoftproduct", "mulesoftproductversion", "mulesoftversion", "mulesoftversionmajor", "mulesoftversionminor", "mulesoftversionpatch", "mulesoftversionwithlatest"]'
+  <atomic-search-interface id="search" fields-to-include='["mulesoftcleantitle", "mulesoftislatestversion", "mulesoftproduct", "mulesoftproductversion", "mulesoftversion", "mulesoftversionmajor", "mulesoftversionminor", "mulesoftversionpatch", "mulesoftversionwithlatest"]'
     {{#if (eq (site-profile) 'jp' )}}search-hub="mulesoft-docs-jp" language="ja"{{else}}search-hub="mulesoft-docs"{{/if}}>
     <atomic-search-layout>
       <atomic-layout-section section="facets">


### PR DESCRIPTION
ref: W-15061326

- upgrade atomic library to 3 following the [upgrade guide](https://docs.coveo.com/en/atomic/latest/atomic-upgrade-from-v2/)
- update the search box field from <input> to <textarea> and adjust CSS accordingly
- update marketing header
- enhance the trending topics fallback logic to handle fallback better (right now if you go to https://beta.docs.mulesoft.com/beta-ui-staging/general/, the trending topic section shows nothing. This change fixes that)

the final product looks almost the same as the current one:
<img width="921" alt="Screenshot 2024-11-04 at 6 34 45 AM" src="https://github.com/user-attachments/assets/2d880aaa-86c5-412c-843a-4bf592b23e21">
