### PR TITLE
[W-17275164] Update EOL support link

### DIFF
--- a/preview-site-src/elements/admonition.adoc
+++ b/preview-site-src/elements/admonition.adoc
@@ -1,7 +1,7 @@
 = Admonition
 :keywords: admonition, admonitions, warning, section, notes
 :page-component-name: elements
-:page-notice-banner-message: This is a <b>custom</b> notice message with a <a href="https://salesforce.com" target="_blank" rel="noopener">link</a>.
+:page-support-status: eolScheduledFeature
 
 https://docs.antora.org/antora/latest/asciidoc/admonitions/[Antora docs reference]
 

--- a/src/partials/notice-banner/eol-reached/banner-for-eol-reached-feature.hbs
+++ b/src/partials/notice-banner/eol-reached/banner-for-eol-reached-feature.hbs
@@ -2,7 +2,7 @@
     <p>
         This feature of the product
         has reached
-        <a class="notice-banner-link" href="https://help.mulesoft.com/s/article/MuleSoft-Product-Feature-Retirements"
+        <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">End of Life</a>.
     </p>
     <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>

--- a/src/partials/notice-banner/eol-reached/banner-for-eol-reached-version.hbs
+++ b/src/partials/notice-banner/eol-reached/banner-for-eol-reached-version.hbs
@@ -1,7 +1,7 @@
 <div class="banner notice-banner flex">
     <p>
         This version of the product has reached
-        <a class="notice-banner-link" href="https://help.mulesoft.com/s/article/MuleSoft-Product-Feature-Retirements"
+        <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">End of Life</a>.
         {{> banner-latest-version-snippet }}
     </p>

--- a/src/partials/notice-banner/eol-reached/banner-for-eol-reached.hbs
+++ b/src/partials/notice-banner/eol-reached/banner-for-eol-reached.hbs
@@ -1,7 +1,7 @@
 <div class="banner notice-banner flex">
     <p>
         This product has reached
-        <a class="notice-banner-link" href="https://help.mulesoft.com/s/article/MuleSoft-Product-Feature-Retirements"
+        <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">End of Life</a>.
     </p>
     <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>

--- a/src/partials/notice-banner/eol-scheduled/banner-for-eol-scheduled-feature.hbs
+++ b/src/partials/notice-banner/eol-scheduled/banner-for-eol-scheduled-feature.hbs
@@ -1,7 +1,7 @@
 <div class="banner notice-banner flex">
     <p>
         This feature of the product is scheduled for
-        <a class="notice-banner-link" href="https://help.mulesoft.com/s/article/MuleSoft-Product-Feature-Retirements"
+        <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">End of Life.</a>
     </p>
     <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>

--- a/src/partials/notice-banner/eol-scheduled/banner-for-eol-scheduled-version.hbs
+++ b/src/partials/notice-banner/eol-scheduled/banner-for-eol-scheduled-version.hbs
@@ -1,7 +1,7 @@
 <div class="banner notice-banner flex">
     <p>
         This version of the product is scheduled for
-        <a class="notice-banner-link" href="https://help.mulesoft.com/s/article/MuleSoft-Product-Feature-Retirements"
+        <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">End of Life.</a>
         {{> banner-latest-version-snippet }}
     </p>

--- a/src/partials/notice-banner/eol-scheduled/banner-for-eol-scheduled.hbs
+++ b/src/partials/notice-banner/eol-scheduled/banner-for-eol-scheduled.hbs
@@ -1,7 +1,7 @@
 <div class="banner notice-banner flex">
     <p>
         This product is scheduled for
-        <a class="notice-banner-link" href="https://help.mulesoft.com/s/article/MuleSoft-Product-Feature-Retirements"
+        <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">End of Life.</a>
     </p>
     <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>

--- a/src/partials/notice-banner/eol-support/banner-for-eol-support-feature.hbs
+++ b/src/partials/notice-banner/eol-support/banner-for-eol-support-feature.hbs
@@ -1,7 +1,7 @@
 <div class="banner notice-banner flex">
     <p>
         This feature of the product has entered
-        <a class="notice-banner-link" href="https://help.mulesoft.com/s/article/MuleSoft-Product-Feature-Retirements"
+        <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">End of Life Support</a>.
     </p>
     <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>

--- a/src/partials/notice-banner/eol-support/banner-for-eol-support-version.hbs
+++ b/src/partials/notice-banner/eol-support/banner-for-eol-support-version.hbs
@@ -1,7 +1,7 @@
 <div class="banner notice-banner flex">
     <p>
         This version of the product has entered
-        <a class="notice-banner-link" href="https://help.mulesoft.com/s/article/MuleSoft-Product-Feature-Retirements"
+        <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">End of Life Support</a>.
         {{> banner-latest-version-snippet }}
     </p>

--- a/src/partials/notice-banner/eol-support/banner-for-eol-support.hbs
+++ b/src/partials/notice-banner/eol-support/banner-for-eol-support.hbs
@@ -1,7 +1,7 @@
 <div class="banner notice-banner flex">
     <p>
         This product has entered
-        <a class="notice-banner-link" href="https://help.mulesoft.com/s/article/MuleSoft-Product-Feature-Retirements"
+        <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">End of Life Support</a>.
     </p>
     <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>

--- a/src/partials/notice-banner/extended-support/banner-for-extended-support-feature.hbs
+++ b/src/partials/notice-banner/extended-support/banner-for-extended-support-feature.hbs
@@ -1,7 +1,7 @@
 <div class="banner notice-banner flex">
     <p>
         This feature of the product has entered
-        <a class="notice-banner-link" href="https://help.mulesoft.com/s/article/MuleSoft-Product-Feature-Retirements"
+        <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">Extended Support</a>.
     </p>
     <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>

--- a/src/partials/notice-banner/extended-support/banner-for-extended-support-version.hbs
+++ b/src/partials/notice-banner/extended-support/banner-for-extended-support-version.hbs
@@ -1,7 +1,7 @@
 <div class="banner notice-banner flex">
     <p>
         This version of the product has entered
-        <a class="notice-banner-link" href="https://help.mulesoft.com/s/article/MuleSoft-Product-Feature-Retirements"
+        <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">Extended Support</a>.
         {{> banner-latest-version-snippet }}
     </p>

--- a/src/partials/notice-banner/extended-support/banner-for-extended-support.hbs
+++ b/src/partials/notice-banner/extended-support/banner-for-extended-support.hbs
@@ -1,7 +1,7 @@
 <div class="banner notice-banner flex">
     <p>
         This product has entered
-        <a class="notice-banner-link" href="https://help.mulesoft.com/s/article/MuleSoft-Product-Feature-Retirements"
+        <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">Extended Support</a>.
     </p>
     <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>


### PR DESCRIPTION
Replaced all references to the old support link on help.mulesoft.com with the new Salesforce support policy.

Also, updated the inline EOL notes in this PR:
https://github.com/mulesoft/docs-reuse/pull/46

**Testing**

Tagged the admonition page in a preview build.
Ran a local build of docs-site-playbook with these changes.

![Screenshot 2024-12-03 at 10 36 00 AM](https://github.com/user-attachments/assets/bfb7c365-c504-4342-99bc-f319a665642e)
