### PR TITLE
[W-17405569] Localize EOL banner text

### DIFF
--- a/preview-site-src-jp/elements/admonition.adoc
+++ b/preview-site-src-jp/elements/admonition.adoc
@@ -1,0 +1,25 @@
+= Admonition
+:keywords: admonition, admonitions, warning, section, notes
+:page-component-name: elements
+:page-support-status: eolReached
+
+https://docs.antora.org/antora/latest/asciidoc/admonitions/[Antora docs reference]
+
+Admonitions created with the `NOTE:` shorthand:
+
+NOTE: If you go into the basement, see if you can find Kenny's `parka`.
+
+TIP: After someone sticks a fork in a socket, you'll need to reset the circuit in the dark basement.
+
+WARNING: Never go into the basement.
+
+CAUTION: Don't stick forks in electric sockets.
+
+IMPORTANT: A monster lives in the basement.
+
+Admonitions created with the longer `[NOTE]` syntax and paragraph wrapping (as it's caused differences in styling before):
+
+[NOTE]
+--
+If you go into the basement, see if you can find Kenny's `parka`.
+--

--- a/preview-site-src-jp/ui-model.yml
+++ b/preview-site-src-jp/ui-model.yml
@@ -52,6 +52,17 @@ site:
             urlType: external
       versions:
       - *general_latest
+    elements:
+      latest: &elements_latest
+        version: ~
+        title: Elements
+        url: '#'
+        navigation:
+        - items:
+          - content: Admonition
+            url: /elements/admonition.html
+      versions:
+      - *elements_latest
     data-gateway:
       latest: &data_gateway_latest
         version: '1.x'

--- a/src/partials/notice-banner/eol-reached/banner-for-eol-reached-feature.hbs
+++ b/src/partials/notice-banner/eol-reached/banner-for-eol-reached-feature.hbs
@@ -1,9 +1,16 @@
 <div class="banner notice-banner flex">
+    {{#if (eq (site-profile) 'jp')}}
+    <p>
+        製品のこの機能は <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
+            target="_blank" rel="noopener noreferrer">サービス終了</a>になっています。
+    </p>
+    {{else}}
     <p>
         This feature of the product
         has reached
         <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">End of Life</a>.
     </p>
+    {{/if}}
     <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>

--- a/src/partials/notice-banner/eol-reached/banner-for-eol-reached-version.hbs
+++ b/src/partials/notice-banner/eol-reached/banner-for-eol-reached-version.hbs
@@ -4,7 +4,6 @@
         製品のこのバージョンは 
         <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">サービス終了</a>になっています。
-        {{> banner-latest-version-snippet }}
     </p>
     {{else}}
     <p>

--- a/src/partials/notice-banner/eol-reached/banner-for-eol-reached-version.hbs
+++ b/src/partials/notice-banner/eol-reached/banner-for-eol-reached-version.hbs
@@ -1,9 +1,18 @@
 <div class="banner notice-banner flex">
+    {{#if (eq (site-profile) 'jp')}}
+    <p>
+        製品のこのバージョンは 
+        <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
+            target="_blank" rel="noopener noreferrer">サービス終了</a>になっています。
+        {{> banner-latest-version-snippet }}
+    </p>
+    {{else}}
     <p>
         This version of the product has reached
         <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">End of Life</a>.
         {{> banner-latest-version-snippet }}
     </p>
+    {{/if}}
     <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>

--- a/src/partials/notice-banner/eol-reached/banner-for-eol-reached.hbs
+++ b/src/partials/notice-banner/eol-reached/banner-for-eol-reached.hbs
@@ -1,8 +1,15 @@
 <div class="banner notice-banner flex">
+    {{#if (eq (site-profile) 'jp')}}
+    <p>
+        この製品は <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
+            target="_blank" rel="noopener noreferrer">サービス終了</a>になっています。
+    </p>
+    {{else}}
     <p>
         This product has reached
         <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">End of Life</a>.
     </p>
+    {{/if}}
     <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>

--- a/src/partials/notice-banner/eol-scheduled/banner-for-eol-scheduled-feature.hbs
+++ b/src/partials/notice-banner/eol-scheduled/banner-for-eol-scheduled-feature.hbs
@@ -1,8 +1,15 @@
 <div class="banner notice-banner flex">
+    {{#if (eq (site-profile) 'jp')}}
+    <p>
+        製品のこの機能は <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
+            target="_blank" rel="noopener noreferrer">サービス終了</a>になる予定です。
+    </p>
+    {{else}}
     <p>
         This feature of the product is scheduled for
         <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">End of Life.</a>
     </p>
+    {{/if}}
     <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>

--- a/src/partials/notice-banner/eol-scheduled/banner-for-eol-scheduled-version.hbs
+++ b/src/partials/notice-banner/eol-scheduled/banner-for-eol-scheduled-version.hbs
@@ -3,7 +3,6 @@
     <p>
         製品のこのバージョンは <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">サービス終了</a>​になる予定です。
-        {{> banner-latest-version-snippet }}
     </p>
     {{else}}
     <p>

--- a/src/partials/notice-banner/eol-scheduled/banner-for-eol-scheduled-version.hbs
+++ b/src/partials/notice-banner/eol-scheduled/banner-for-eol-scheduled-version.hbs
@@ -1,9 +1,17 @@
 <div class="banner notice-banner flex">
+    {{#if (eq (site-profile) 'jp')}}
+    <p>
+        製品のこのバージョンは <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
+            target="_blank" rel="noopener noreferrer">サービス終了</a>​になる予定です。
+        {{> banner-latest-version-snippet }}
+    </p>
+    {{else}}
     <p>
         This version of the product is scheduled for
         <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">End of Life.</a>
         {{> banner-latest-version-snippet }}
     </p>
+    {{/if}}
     <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>

--- a/src/partials/notice-banner/eol-scheduled/banner-for-eol-scheduled.hbs
+++ b/src/partials/notice-banner/eol-scheduled/banner-for-eol-scheduled.hbs
@@ -1,8 +1,15 @@
 <div class="banner notice-banner flex">
+    {{#if (eq (site-profile) 'jp')}}
+    <p>
+        この製品は <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
+            target="_blank" rel="noopener noreferrer">サービス終了</a>になる予定です。
+    </p>
+    {{else}}
     <p>
         This product is scheduled for
         <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">End of Life.</a>
     </p>
+    {{/if}}
     <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>

--- a/src/partials/notice-banner/extended-support/banner-for-extended-support-feature.hbs
+++ b/src/partials/notice-banner/extended-support/banner-for-extended-support-feature.hbs
@@ -1,8 +1,15 @@
 <div class="banner notice-banner flex">
+    {{#if (eq (site-profile) 'jp')}}
+    <p>
+        製品のこの機能は <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
+            target="_blank" rel="noopener noreferrer">延長サポート</a>​に入りました。
+    </p>
+    {{else}}
     <p>
         This feature of the product has entered
         <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">Extended Support</a>.
     </p>
+    {{/if}}
     <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>

--- a/src/partials/notice-banner/extended-support/banner-for-extended-support-version.hbs
+++ b/src/partials/notice-banner/extended-support/banner-for-extended-support-version.hbs
@@ -3,7 +3,6 @@
     <p>
         製品のこのバージョンは <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">延長サポート</a>に入りました。
-        {{> banner-latest-version-snippet }}
     </p>
     {{else}}
     <p>

--- a/src/partials/notice-banner/extended-support/banner-for-extended-support-version.hbs
+++ b/src/partials/notice-banner/extended-support/banner-for-extended-support-version.hbs
@@ -1,9 +1,17 @@
 <div class="banner notice-banner flex">
+    {{#if (eq (site-profile) 'jp')}}
+    <p>
+        製品のこのバージョンは <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
+            target="_blank" rel="noopener noreferrer">延長サポート</a>に入りました。
+        {{> banner-latest-version-snippet }}
+    </p>
+    {{else}}
     <p>
         This version of the product has entered
         <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">Extended Support</a>.
         {{> banner-latest-version-snippet }}
     </p>
+    {{/if}}
     <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>

--- a/src/partials/notice-banner/extended-support/banner-for-extended-support.hbs
+++ b/src/partials/notice-banner/extended-support/banner-for-extended-support.hbs
@@ -1,8 +1,15 @@
 <div class="banner notice-banner flex">
+    {{#if (eq (site-profile) 'jp')}}
+    <p>
+        この製品は <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
+            target="_blank" rel="noopener noreferrer">延長サポート</a>に入りました。
+    </p>
+    {{else}}
     <p>
         This product has entered
         <a class="notice-banner-link" href="https://www.salesforce.com/content/dam/web/en_us/www/documents/legal/Agreements/versioning-back-support-policy.pdf"
             target="_blank" rel="noopener noreferrer">Extended Support</a>.
     </p>
+    {{/if}}
     <button aria-label="Close notice banner" class="close-button" title="Close notice banner"><img loading="lazy" src="{{@root.uiRootPath}}/img/icons/close.svg" alt=""></button>
 </div>


### PR DESCRIPTION
This PRs copies the translations from the [EOL notes in docs-reuse](https://github.com/mulesoft/docs-reuse-jp/blob/latest/modules/ROOT/partials/eol-note.adoc?plain=1) and uses it for our EOL banners which are currently English-only.

A couple of caveats:
* The [EOL support banners](https://github.com/mulesoft/docs-site-ui/tree/main/src/partials/notice-banner/eol-support) do not have translations as they don't have corresponding EOL notes in docs-reuse. However, there's only [one page](https://github.com/search?q=org%3Amulesoft%20%3Apage-support-status%3A%20eolSupport&type=code) in our docs currently using that banner. I think this is a rare enough case that it's fine to leave these alone, so I'm punting on requesting translations.
* I'm not including the `{{> banner-latest-version-snippet }}` text in the JP version. These links to the latest version always point to the English site, and we don't have translated text for the snippet either.

**Testing**

Verified in the local preview, and double-checked with Google Translate that the strings I copied in made sense.

![Screenshot 2024-12-18 at 11 56 27 AM](https://github.com/user-attachments/assets/225c1c43-cb40-4100-bd63-520ac442ef0b)

Ran JP docs-site-playbook builds for final verification.

![Screenshot 2024-12-18 at 1 44 04 PM](https://github.com/user-attachments/assets/5130ef9a-170e-4898-b27c-cd0fa76051a9)

