### PR TITLE
[W-17901709] bugfix: latest releases month format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "mulesoft-docs-site-ui",
       "devDependencies": {
         "@asciidoctor/core": "~2.2",
-        "@asciidoctor/tabs": "*",
+        "@asciidoctor/tabs": "latest",
         "@mulesoft/lume-icon": "^0.1.47",
         "@mulesoft/lume-styling-hooks": "1.0.23",
         "@octokit/rest": "20.1.1",
@@ -722,10 +722,11 @@
       }
     },
     "node_modules/@octokit/endpoint": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.5.tgz",
-      "integrity": "sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/types": "^13.1.0",
         "universal-user-agent": "^6.0.0"
@@ -735,12 +736,13 @@
       }
     },
     "node_modules/@octokit/graphql": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.0.tgz",
-      "integrity": "sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@octokit/request": "^8.3.0",
+        "@octokit/request": "^8.4.1",
         "@octokit/types": "^13.0.0",
         "universal-user-agent": "^6.0.0"
       },
@@ -797,13 +799,14 @@
       }
     },
     "node_modules/@octokit/request": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.0.tgz",
-      "integrity": "sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@octokit/endpoint": "^9.0.1",
-        "@octokit/request-error": "^5.1.0",
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
         "@octokit/types": "^13.1.0",
         "universal-user-agent": "^6.0.0"
       },
@@ -812,10 +815,11 @@
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.0.tgz",
-      "integrity": "sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@octokit/types": "^13.1.0",
         "deprecation": "^2.0.0",

--- a/src/css/globals/global.css
+++ b/src/css/globals/global.css
@@ -45,6 +45,10 @@ body {
       }
     }
   }
+
+  &.with-promo-banner.header-scrolled:not(.header-promo-closed, .promo-closed) {
+    padding-top: var(--header-height);
+  }
 }
 
 .help-text {

--- a/src/css/globals/global.css
+++ b/src/css/globals/global.css
@@ -45,10 +45,6 @@ body {
       }
     }
   }
-
-  &.with-promo-banner.header-scrolled:not(.header-promo-closed, .promo-closed) {
-    padding-top: var(--header-height);
-  }
 }
 
 .help-text {

--- a/src/helpers/release-notes.js
+++ b/src/helpers/release-notes.js
@@ -88,7 +88,7 @@ const isVersion = (versionText) => {
 const removeYear = (dateStr) => {
   if (isValidDate(dateStr)) {
     const dateObj = new Date(dateStr)
-    return `${dateObj.toLocaleString('default', {
+    return `${dateObj.toLocaleString('en-US', {
       month: 'short',
     })} ${dateObj.getDate()}`
   }


### PR DESCRIPTION
ref: W-17901709

fix month format in the "Latest Releases" section.

before:
<img width="327" alt="Screenshot 2025-02-25 at 8 41 10 AM" src="https://github.com/user-attachments/assets/fe46600d-8d7a-4b78-8a5e-8db5cc628714" />

after:
<img width="325" alt="Screenshot 2025-02-25 at 8 40 17 AM" src="https://github.com/user-attachments/assets/0e2b79a7-8999-400f-859c-5c1e84008a52" />

validated via local build (`npm run format:bundle` then build it using a test playbook)
