### PR TITLE
[W-17866218] Add learning map icon, fix alignment and margins

### DIFF
--- a/src/css/pages/learning-map.css
+++ b/src/css/pages/learning-map.css
@@ -5,6 +5,11 @@
       padding-left: 0;
     }
 
+    & p {
+      margin-bottom: 0;
+      margin-top: 0;
+    }
+
     & li p {
       padding-bottom: 0;
     }

--- a/src/css/pages/learning-map.css
+++ b/src/css/pages/learning-map.css
@@ -1,17 +1,15 @@
 .learning-map {
-  .lm-table {
+  /* Workaround: Increase specificity to override high specificity rules in table.css */
+  .lm-table.lm-table.lm-table {
     & ul {
       list-style-type: none;
+      margin-left: 24px;
       padding-left: 0;
     }
 
     & p {
       margin-bottom: 0;
       margin-top: 0;
-    }
-
-    & li p {
-      padding-bottom: 0;
     }
 
     .lm-bold {
@@ -23,7 +21,8 @@
       content: "";
       display: inline-block;
       height: 24px;
-      margin-right: 5px; /* Adds spacing between icon and text */
+      margin-left: -28px;
+      margin-right: 4px;
       vertical-align: middle;
       width: 24px;
     }

--- a/src/js/09-external-links.js
+++ b/src/js/09-external-links.js
@@ -34,14 +34,12 @@
   const opensInNewWindow = (linkTarget) => linkTarget === '_blank'
 
   const processExternalLinks = (selectors) => {
-    if (document.querySelector(learningMapSelector)) return
-
     const selectorText = selectors.map((el) => `${el} :not(#trending-topics-fallback) > * > a`).join(', ')
     const externalLinks = document.querySelectorAll(selectorText)
     externalLinks.forEach((externalLink) => {
       if (isExternalLink(externalLink.href)) {
         if (!opensInNewWindow(externalLink.target)) externalLink.target = '_blank'
-        appendExternalLinkIcon(externalLink)
+        if (!document.querySelector(learningMapSelector)) appendExternalLinkIcon(externalLink)
       }
     })
   }

--- a/src/js/vendor/icondefs.js
+++ b/src/js/vendor/icondefs.js
@@ -1117,6 +1117,25 @@
       ],
     },
     {
+      id: 'icon-nav-page-general-learning-map-api-management',
+      viewBox: '0 0 24 24',
+      paths: [
+        // lume-icons/utility/api-group
+        {
+          d: 'M11.514 1.126a1 1 0 0 1 .972 0l9 5A1 1 0 0 1 22 7v10a1 1 0 0 1-.514.874l-9 5a1 1 0 0 1-.972 0l-9-5A1 1 0 0 1 2 17V7a1 1 0 0 1 .514-.874l9-5ZM4 7.588v8.824l8 4.444 8-4.444V7.588l-8-4.444-8 4.444Z',
+          fill: 'var(--lume-c-icon-color-foreground-3)',
+        },
+        {
+          d: 'M11.514 5.626a1 1 0 0 1 .972 0l5 2.78A1 1 0 0 1 18 9.28V15a1 1 0 1 1-2 0V9.868l-4-2.224-4 2.224V15a1 1 0 1 1-2 0V9.28a1 1 0 0 1 .514-.874l5-2.78Z',
+          fill: 'var(--lume-c-icon-color-foreground-3)',
+        },
+        {
+          d: 'M12 9.5a1 1 0 0 1 1 1v1a1 1 0 1 1-2 0v-1a1 1 0 0 1 1-1ZM12 14a1 1 0 0 1 1 1v3a1 1 0 1 1-2 0v-3a1 1 0 0 1 1-1Z',
+          fill: 'var(--lume-c-icon-color-foreground-3)',
+        },
+      ],
+    },
+    {
       id: 'icon-nav-page-general-contribute',
       viewBox: '0 0 24 24',
       paths: [


### PR DESCRIPTION
Added an icon for the learning map in the TOC:

![Screenshot 2025-02-25 at 10 03 02 AM](https://github.com/user-attachments/assets/c88659b8-8450-422a-8107-ba67e25ca359)

Changed the behavior of external links in learning maps. Writers want these to open in new windows like they usually do. I'm still hiding the link icon though to avoid wrapping issues like this:

![Screenshot 2025-02-25 at 11 30 24 AM](https://github.com/user-attachments/assets/4a37b3eb-7ffb-4f26-993f-e7829f56cff2)

Fixed an issue where the first column of the learning map table had different spacing between lines than the others. It turned out there was something in table.css overriding the expected behavior. I tightened up the spacing while I was looking at it.

![Screenshot 2025-02-25 at 11 27 59 AM](https://github.com/user-attachments/assets/20e0fcb7-d42d-4810-942b-38d83f935ac7)


**Testing**

Tested in local preview.
Tested in full build.