### PR TITLE
[W-17952016] bugfix - breadcrumbs not showing gateway parent pages

### DIFF
--- a/src/partials/toolbar/breadcrumbs.hbs
+++ b/src/partials/toolbar/breadcrumbs.hbs
@@ -22,7 +22,7 @@
     <li class="flex align-center li">
       <p>{{{./content}}}{{#if (and (not (is-null @root.page.version)) (not (is-one-of @root.page.version 'default' 'latest' 'master' '~')) (or (eq ./url @root.page.breadcrumbs.0.url) (and (ends-with ./url "index.html"))))}} <span class="breadcrumbs-item-version">({{ @root.page.version }})</span>{{/if}}</p>
     </li>
-    {{else if (ne ./url @root.page.breadcrumbs.0.url)}}
+    {{else if (not ./root)}}
     <li class="flex align-center li"><a class="link" href="{{{relativize ./url}}}">{{{./content}}}</a></li>
     {{/if}}
   {{/if}}


### PR DESCRIPTION
ref: [W-17952016](https://gus.lightning.force.com/a07EE00002Aa1D2YAJ)

this PR updates the breadcrumbs logic for checking root pages so that breadcrumbs are showing. If you run `{{log .}}` after line 20 of breadcrumbs.hbs, you can see something like this:

```json
{
  content: 'DataWeave',
  url: '/dataweave/latest/index.html',
  urlType: 'internal',
  items: [
    {
      content: 'Overview',
      url: '/dataweave/latest/index.html',
      urlType: 'internal'
    },
    {
      content: 'Release Notes',
      url: '/dataweave/latest/dataweave-release-notes.html',
      urlType: 'internal'
    },
    {
      content: 'DataWeave Quickstart',
      url: '/dataweave/latest/dataweave-quickstart.html',
      urlType: 'internal'
    },
    {
      content: 'Language Guide',
      url: '/dataweave/latest/dataweave-language-guide.html',
      urlType: 'internal',
      items: [Array]
    },
    {
      content: 'DataWeave Examples',
      url: '/dataweave/latest/dataweave-cookbook.html',
      urlType: 'internal',
      items: [Array]
    },
    {
      content: 'DataWeave Reference',
      url: '/dataweave/latest/dw-functions.html',
      urlType: 'internal',
      items: [Array]
    }
  ],
  root: true,
  order: 0
}
```

if the breadcrumb page (not the actual page, but the page being referenced in the breadcrumbs) is a root page, it will contain the key/value `root: true`, otherwise that key/value does not exist.

### How to test

1. Create a local build, with gateway and dataweave at the minimum
2. Open **build/site/gateway/latest/flex-install.html**, make sure the breadcrumbs read `Flex Gateway (1.8) > Setting Up Flex Gateway > Download Flex Gateway` instead of `Flex Gateway (1.8) > Download Flex Gateway`
3. [regression test] Open **build/site/dataweave/latest/dataweave-language-guide.html**, make sure that the breadcrumbs read `DataWeave (2.9) > Language Guide` instead of `DataWeave (2.9) > DataWeave > Language Guide`
