### PR TITLE
[W-18013982] fix search bar CSS and set analytics mode to legacy

### DIFF
--- a/src/css/globals/global.css
+++ b/src/css/globals/global.css
@@ -53,9 +53,17 @@ body {
           top: 0 !important;
         }
 
+        & .search-toolbar {
+          padding-top: var(--sm) !important;
+        }
+
         &:has(.top-banner:not(.hide)) {
           & > div.flex.container.wrapper {
             transform: translateY(50px);
+          }
+
+          & .search-toolbar {
+            padding-top: 60px !important;
           }
         }
       }
@@ -67,6 +75,10 @@ body {
 
         & .top-banner {
           top: var(--header-height);
+        }
+
+        & .search-toolbar {
+          padding-top: 85px;
         }
       }
   

--- a/src/partials/head/head-links.hbs
+++ b/src/partials/head/head-links.hbs
@@ -11,3 +11,6 @@
 {{/unless}}
 <link rel="icon" href="{{@root.uiRootPath}}/img/favicon.ico" type="image/x-icon">
 <link rel="stylesheet" href="{{@root.uiRootPath}}/css/site.css">
+<link
+    rel="stylesheet"
+    href="https://static.cloud.coveo.com/atomic/v3/themes/coveo.css"/>

--- a/src/partials/head/head-links.hbs
+++ b/src/partials/head/head-links.hbs
@@ -11,6 +11,3 @@
 {{/unless}}
 <link rel="icon" href="{{@root.uiRootPath}}/img/favicon.ico" type="image/x-icon">
 <link rel="stylesheet" href="{{@root.uiRootPath}}/css/site.css">
-<link
-    rel="stylesheet"
-    href="https://static.cloud.coveo.com/atomic/v3/themes/coveo.css"/>

--- a/src/partials/head/head-scripts/coveo-search-scripts.hbs
+++ b/src/partials/head/head-scripts/coveo-search-scripts.hbs
@@ -1,8 +1,7 @@
 <script
   type="module"
-  src="https://static.cloud.coveo.com/atomic/v3.7.0/atomic.esm.js"
-  integrity="sha512-fLs7ot1PpQgZRoHpoVrxF2zWq6OZsKE7uaZYVmiTnmwTUIehgr/nvfNhqcbPP0PWfy81tEBxMcXJe8H67sA1Pg=="
-  crossorigin="anonymous">
+  src="https://static.cloud.coveo.com/atomic/v3.19.1/atomic.esm.js"
+>
 </script>
 <script nonce="**CSP_NONCE**">
   (async () => {
@@ -12,6 +11,7 @@
       if (searchInterface) {
         await searchInterface.initialize({
           accessToken,
+          analytics: {analyticsMode: 'legacy'},
           organizationId,
         });
         if (window.location.href.includes('/search')) searchInterface.executeFirstSearch();


### PR DESCRIPTION
ref: W-18013982

- adjust the top padding of the search bar so that it is no longer blocked by the agentforce promo banner
- upgrade coveo atomic library
- update analytics mode to legacy. This was recommended by our customer success manager Renee to allow user analytics events to process correctly. See [Coveo doc](https://docs.coveo.com/en/atomic/latest/usage/atomic-usage-analytics/#:~:text=Only%20Coveo%20for%20Commerce%20supports%20EP%20at%20the%20moment.%20For%20every%20other%20kind%20of%20implementation%2C%20set%20analyticsMode%20to%20legacy%20for%20the%20time%20being.) for further detail.