### PR TITLE
[W-17627001] Fix: nav-version-menu includes listbox aria role without required children

### DIFF
--- a/src/css/components/tooltip.css
+++ b/src/css/components/tooltip.css
@@ -48,7 +48,7 @@
   }
 
   &.tooltip-dot-nav-version {
-    margin-left: 6px;
+    margin-left: -12px;
     margin-top: 8px;
   }
 }

--- a/src/css/specific/nav.css
+++ b/src/css/specific/nav.css
@@ -391,13 +391,14 @@ svg.nav-icon {
       max-height 0s var(--transition-speed-sm);
   }
 
-  & button,
-  & span:not(.tooltip-dot-nav-version-menu, .tooltip-dot-nav-version) {
+  & .nav-version-option,
+  & .nav-version-label {
     display: list-item;
     padding: var(--xs) var(--input-md) var(--xs) var(--sm);
   }
 
   & .nav-version-label {
+    clear: both;
     font-weight: var(--weight-bold);
   }
 
@@ -421,6 +422,8 @@ svg.nav-icon {
     color: var(--steel-3);
     cursor: pointer;
     float: right;
+    font-size: 13px;
+    font-weight: normal;
     text-align: left;
     width: 90%;
 

--- a/src/partials/header/header-content-archive.hbs
+++ b/src/partials/header/header-content-archive.hbs
@@ -3,7 +3,7 @@
     <div>
       <div id="promotion_banner_agentforce" class="promotion-banner dark-blue-banner SL_swap">
         <div class="promotion-banner-inside">
-          <div class="field field--block-content-field-headline field--name-field-headline field--type-string field--label-hidden field__item">Hear from Salesforce leaders on how to create and deploy Agentforce agents.</div>
+          <div class="field field--block-content-field-headline field--name-field-headline field--type-string field--label-hidden field__item">Learn how to put your digital team to work with MuleSoft for Agentforce.</div>
           <div class="field field--block-content-field-subhead field--name-field-subhead field--type-text-long field--label-hidden field__item">
             <style>
               @media screen and (max-width: 992px) {
@@ -13,7 +13,7 @@
               }
             </style>
           </div>
-          <div class="field-block-content--field-cta"> <a href="https://www.salesforce.com/form/events/webinars/form-rss/4783828" target="_blank" onclick="">Register now</a></div> <button class="cross" onclick="closePromoBanner()">+</button>
+          <div class="field-block-content--field-cta"> <a href="https://www.salesforce.com/form/events/webinars/form-rss/4900882" target="_blank" onclick="">Register now</a></div> <button class="cross" onclick="closePromoBanner()">+</button>
         </div>
       </div>
     </div>
@@ -120,7 +120,7 @@
                           <div class="full-left-menu">
                             <div class="mega-menu-container-left">
                               <div class="services-menu">
-                                <nav class="menu"> <span class="menu-label" role="heading">Training</span> <a class="services-title" href="https://trailheadacademy.salesforce.com/products/mulesoft#f-products=Mulesoft" target="&rdquo;_blank&rdquo;" role="menuitem">Courses</a> <a class="services-title" href="https://trailhead.salesforce.com/en/credentials/administratoroverview/" target="&rdquo;_blank&rdquo;" role="menuitem">Certifications</a> <a class="services-title" href="https://trailhead.salesforce.com/help?article=Salesforce-Learning-Credits-FAQ-and-Redemption-Process" target="&rdquo;_blank&rdquo;" role="menuitem">Training credits</a> </nav>
+                                <nav class="menu"> <span class="menu-label" role="heading">Training</span> <a class="services-title" href="https://trailheadacademy.salesforce.com/products/mulesoft#f-products=Mulesoft" target="&rdquo;_blank&rdquo;" role="menuitem">Courses</a> <a class="services-title" href="https://trailheadacademy.salesforce.com/products/mulesoft#f-products=MuleSoft%E2%80%9D%20target=%E2%80%9D_blank%E2%80%9D%20role=" menuitem>Certifications</a> <a class="services-title" href="https://trailhead.salesforce.com/help?article=Salesforce-Learning-Credits-FAQ-and-Redemption-Process" target="&rdquo;_blank&rdquo;" role="menuitem">Training credits</a> </nav>
                                 <nav class="menu"> <span class="menu-label" role="heading">Customer success</span> <a class="services-title" href="https://www.mulesoft.com/support-and-services/consulting" role="menuitem">MuleSoft Catalyst</a> <a class="services-title" href="https://www.mulesoft.com/support-and-services/mobilize-consulting-solutions" role="menuitem">Business Value Services</a> </nav>
                                 <nav class="menu"> <span class="menu-label" role="heading">Support</span> <a class="services-title" href="https://help.mulesoft.com/s/" role="menuitem">Help Center</a> <a class="services-title" href="https://www.mulesoft.com/community" role="menuitem">Community Forums</a> <a class="services-title" href="https://help.mulesoft.com/s/resources" role="menuitem">Resources</a> </nav>
                               </div>
@@ -351,7 +351,7 @@
                           <div class="full-left-menu">
                             <div class="mega-menu-container-left">
                               <div class="services-menu">
-                                <nav class="menu"> <span class="menu-label" role="heading">Training</span> <a class="services-title" href="https://trailheadacademy.salesforce.com/products/mulesoft#f-products=Mulesoft" target="&rdquo;_blank&rdquo;" role="menuitem">Courses</a> <a class="services-title" href="https://trailhead.salesforce.com/en/credentials/administratoroverview/" target="&rdquo;_blank&rdquo;" role="menuitem">Certifications</a> <a class="services-title" href="https://trailhead.salesforce.com/help?article=Salesforce-Learning-Credits-FAQ-and-Redemption-Process" target="&rdquo;_blank&rdquo;" role="menuitem">Training credits</a> </nav>
+                                <nav class="menu"> <span class="menu-label" role="heading">Training</span> <a class="services-title" href="https://trailheadacademy.salesforce.com/products/mulesoft#f-products=Mulesoft" target="&rdquo;_blank&rdquo;" role="menuitem">Courses</a> <a class="services-title" href="https://trailheadacademy.salesforce.com/products/mulesoft#f-products=MuleSoft%E2%80%9D%20target=%E2%80%9D_blank%E2%80%9D%20role=" menuitem>Certifications</a> <a class="services-title" href="https://trailhead.salesforce.com/help?article=Salesforce-Learning-Credits-FAQ-and-Redemption-Process" target="&rdquo;_blank&rdquo;" role="menuitem">Training credits</a> </nav>
                                 <nav class="menu"> <span class="menu-label" role="heading">Customer success</span> <a class="services-title" href="https://www.mulesoft.com/support-and-services/consulting" role="menuitem">MuleSoft Catalyst</a> <a class="services-title" href="https://www.mulesoft.com/support-and-services/mobilize-consulting-solutions" role="menuitem">Business Value Services</a> </nav>
                                 <nav class="menu"> <span class="menu-label" role="heading">Support</span> <a class="services-title" href="https://help.mulesoft.com/s/" role="menuitem">Help Center</a> <a class="services-title" href="https://www.mulesoft.com/community" role="menuitem">Community Forums</a> <a class="services-title" href="https://help.mulesoft.com/s/resources" role="menuitem">Resources</a> </nav>
                               </div>

--- a/src/partials/header/header-content-en.hbs
+++ b/src/partials/header/header-content-en.hbs
@@ -3,7 +3,7 @@
     <div>
       <div id="promotion_banner_agentforce" class="promotion-banner dark-blue-banner SL_swap">
         <div class="promotion-banner-inside">
-          <div class="field field--block-content-field-headline field--name-field-headline field--type-string field--label-hidden field__item">Hear from Salesforce leaders on how to create and deploy Agentforce agents.</div>
+          <div class="field field--block-content-field-headline field--name-field-headline field--type-string field--label-hidden field__item">Learn how to put your digital team to work with MuleSoft for Agentforce.</div>
           <div class="field field--block-content-field-subhead field--name-field-subhead field--type-text-long field--label-hidden field__item">
             <style>
               @media screen and (max-width: 992px) {
@@ -13,7 +13,7 @@
               }
             </style>
           </div>
-          <div class="field-block-content--field-cta"> <a href="https://www.salesforce.com/form/events/webinars/form-rss/4783828" target="_blank" onclick="">Register now</a></div> <button class="cross" onclick="closePromoBanner()">+</button>
+          <div class="field-block-content--field-cta"> <a href="https://www.salesforce.com/form/events/webinars/form-rss/4900882" target="_blank" onclick="">Register now</a></div> <button class="cross" onclick="closePromoBanner()">+</button>
         </div>
       </div>
     </div>
@@ -120,7 +120,7 @@
                           <div class="full-left-menu">
                             <div class="mega-menu-container-left">
                               <div class="services-menu">
-                                <nav class="menu"> <span class="menu-label" role="heading">Training</span> <a class="services-title" href="https://trailheadacademy.salesforce.com/products/mulesoft#f-products=Mulesoft" target="&rdquo;_blank&rdquo;" role="menuitem">Courses</a> <a class="services-title" href="https://trailhead.salesforce.com/en/credentials/administratoroverview/" target="&rdquo;_blank&rdquo;" role="menuitem">Certifications</a> <a class="services-title" href="https://trailhead.salesforce.com/help?article=Salesforce-Learning-Credits-FAQ-and-Redemption-Process" target="&rdquo;_blank&rdquo;" role="menuitem">Training credits</a> </nav>
+                                <nav class="menu"> <span class="menu-label" role="heading">Training</span> <a class="services-title" href="https://trailheadacademy.salesforce.com/products/mulesoft#f-products=Mulesoft" target="&rdquo;_blank&rdquo;" role="menuitem">Courses</a> <a class="services-title" href="https://trailheadacademy.salesforce.com/products/mulesoft#f-products=MuleSoft%E2%80%9D%20target=%E2%80%9D_blank%E2%80%9D%20role=" menuitem>Certifications</a> <a class="services-title" href="https://trailhead.salesforce.com/help?article=Salesforce-Learning-Credits-FAQ-and-Redemption-Process" target="&rdquo;_blank&rdquo;" role="menuitem">Training credits</a> </nav>
                                 <nav class="menu"> <span class="menu-label" role="heading">Customer success</span> <a class="services-title" href="https://www.mulesoft.com/support-and-services/consulting" role="menuitem">MuleSoft Catalyst</a> <a class="services-title" href="https://www.mulesoft.com/support-and-services/mobilize-consulting-solutions" role="menuitem">Business Value Services</a> </nav>
                                 <nav class="menu"> <span class="menu-label" role="heading">Support</span> <a class="services-title" href="https://help.mulesoft.com/s/" role="menuitem">Help Center</a> <a class="services-title" href="https://www.mulesoft.com/community" role="menuitem">Community Forums</a> <a class="services-title" href="https://help.mulesoft.com/s/resources" role="menuitem">Resources</a> </nav>
                               </div>
@@ -367,7 +367,7 @@
                           <div class="full-left-menu">
                             <div class="mega-menu-container-left">
                               <div class="services-menu">
-                                <nav class="menu"> <span class="menu-label" role="heading">Training</span> <a class="services-title" href="https://trailheadacademy.salesforce.com/products/mulesoft#f-products=Mulesoft" target="&rdquo;_blank&rdquo;" role="menuitem">Courses</a> <a class="services-title" href="https://trailhead.salesforce.com/en/credentials/administratoroverview/" target="&rdquo;_blank&rdquo;" role="menuitem">Certifications</a> <a class="services-title" href="https://trailhead.salesforce.com/help?article=Salesforce-Learning-Credits-FAQ-and-Redemption-Process" target="&rdquo;_blank&rdquo;" role="menuitem">Training credits</a> </nav>
+                                <nav class="menu"> <span class="menu-label" role="heading">Training</span> <a class="services-title" href="https://trailheadacademy.salesforce.com/products/mulesoft#f-products=Mulesoft" target="&rdquo;_blank&rdquo;" role="menuitem">Courses</a> <a class="services-title" href="https://trailheadacademy.salesforce.com/products/mulesoft#f-products=MuleSoft%E2%80%9D%20target=%E2%80%9D_blank%E2%80%9D%20role=" menuitem>Certifications</a> <a class="services-title" href="https://trailhead.salesforce.com/help?article=Salesforce-Learning-Credits-FAQ-and-Redemption-Process" target="&rdquo;_blank&rdquo;" role="menuitem">Training credits</a> </nav>
                                 <nav class="menu"> <span class="menu-label" role="heading">Customer success</span> <a class="services-title" href="https://www.mulesoft.com/support-and-services/consulting" role="menuitem">MuleSoft Catalyst</a> <a class="services-title" href="https://www.mulesoft.com/support-and-services/mobilize-consulting-solutions" role="menuitem">Business Value Services</a> </nav>
                                 <nav class="menu"> <span class="menu-label" role="heading">Support</span> <a class="services-title" href="https://help.mulesoft.com/s/" role="menuitem">Help Center</a> <a class="services-title" href="https://www.mulesoft.com/community" role="menuitem">Community Forums</a> <a class="services-title" href="https://help.mulesoft.com/s/resources" role="menuitem">Resources</a> </nav>
                               </div>


### PR DESCRIPTION
Here is an example of the error from Evinced: https://app.evinced.com/properties/cb70a00e-5e97-494b-ae37-ae213b71d31c/scans/a6aeafeb-512f-457d-b00a-bfae0162063d/issues/e221cdff-a809-4abb-b139-8fb4af6c5df8

`Element has children which are not allowed: span[tabindex], button[tabindex]`

Here is their reference page: https://knowledge.evinced.com/system-validations/aria-required-children

In other words, elements with the `listbox` role can't have arbitrary children--they need to be children with the `option` role per this [page on MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/listbox_role).

I've updated the structure of our menus to match the [Listbox example with grouped children](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/examples/listbox-grouped/) on the W3C Aria site.

To make it a bit easier to see the change in HTML structure, here's a diff of the rendered HTML:
![Screenshot 2025-04-01 at 7 13 43 PM](https://github.com/user-attachments/assets/2948c9fa-3cc1-4661-bdb4-8d4203048e01)

**Testing**

Tested with a full build of the English and Archive sites.
