### PR TITLE
[W-18762356] Fix: Extraneous spacing after TOC items with single version badge

### DIFF
--- a/src/css/adoc/doc.css
+++ b/src/css/adoc/doc.css
@@ -399,6 +399,10 @@
   margin-top: 24px !important;
 }
 
+p.badge {
+  margin-bottom: 8px;
+}
+
 p.badge,
 p.prev-flag {
   background: #e3066a;
@@ -409,7 +413,6 @@ p.prev-flag {
   font-size: 12px !important;
   letter-spacing: 0;
   line-height: 25px !important;
-  margin-bottom: 8px;
   padding: 0 18px;
 
   &.square {


### PR DESCRIPTION
The lower margin of some TOC items is too big. This is fallout from the restructuring of the nav HTML for previous accessibility work, and affects TOC item which only have one version listed.

Example of extraneous spacing:
![Screenshot 2025-06-13 at 8 57 19 AM](https://github.com/user-attachments/assets/4d78f659-bbc2-4059-af70-f61807d8cf39)

**Testing**

Tested in local preview.