### PR TITLE
[W-19433146] Help minimap icons should display for more URL patterns

### DIFF
--- a/preview-site-src/general/learning-map-api-management.adoc
+++ b/preview-site-src/general/learning-map-api-management.adoc
@@ -15,6 +15,8 @@ API management helps ensure that APIs are reliable, secure, and easy to use, whi
 
 - https://www.mulesoft.com/api/management[Anypoint Platform API Management]
 - xref:api-led-deploy.adoc[Test Xref] (This only shows the help icon on full builds, not in preview.)
+- https://developer.salesforce.com/docs/einstein/genai/guide/models-api-build-lwc-flow.html[Link to Salesforce Developer Docs]
+- https://help.salesforce.com/s/articleView?id=ai.einstein_sales.htm&type=5[Link to Salesforce Help Docs]
 
 | image::../_/img/learning-map/lm_explore_1.png[]
 [.lm-bold]##Design and Build##

--- a/src/js/09-external-links.js
+++ b/src/js/09-external-links.js
@@ -57,7 +57,12 @@
         link.classList.add('lm-link-video')
       } else if (href.startsWith('https://trailhead.salesforce.com')) {
         link.classList.add('lm-link-trailhead')
-      } else if (link.classList.contains('xref') || href.startsWith('https://docs.mulesoft.com')) {
+      } else if (
+        link.classList.contains('xref') ||
+        href.startsWith('https://docs.mulesoft.com') ||
+        href.startsWith('https://help.salesforce.com/s/articleView') ||
+        href.startsWith('https://developer.salesforce.com/docs')
+      ) {
         link.classList.add('lm-link-help')
       } else if (href.startsWith('https://www.mulesoft.com')) {
         link.classList.add('lm-link-marketing')


### PR DESCRIPTION
On learning map pages, display the help minimap icon for Salesforce Help and Developer Docs links.

**Testing**

Added test links to local learning map and tested:

<img width="272" height="71" alt="Screenshot 2025-08-26 at 9 40 05 AM" src="https://github.com/user-attachments/assets/a34dc456-0e39-4157-abca-402a045dd618" />

