### PR TITLE
[W-19478418] Do not insert docsearch script on beta site

### DIFF
--- a/src/partials/footer/footer-scripts.hbs
+++ b/src/partials/footer/footer-scripts.hbs
@@ -4,5 +4,7 @@
 <script src="{{uiRootPath}}/js/vendor/tippy.js"></script>
 <script src="{{uiRootPath}}/js/site.js" id="site-script" data-ui-root-path="{{uiRootPath}}"></script>
 <script async src="{{uiRootPath}}/js/vendor/highlight.js"></script>
+{{#if (or preview (is-one-of (site-profile) 'prod' 'jp'))}}
 {{> docsearch-scripts }}
+{{/if}}
 {{> marketing-scripts}}

--- a/src/partials/head/head-links.hbs
+++ b/src/partials/head/head-links.hbs
@@ -11,6 +11,6 @@
 {{/unless}}
 <link rel="icon" href="{{@root.uiRootPath}}/img/favicon.ico" type="image/x-icon">
 <link rel="stylesheet" href="{{@root.uiRootPath}}/css/site.css">
-{{#if env.DOCSEARCH_APP_ID }}
+{{#if (or preview (is-one-of (site-profile) 'prod' 'jp'))}}
 <link rel="preconnect" href="https://{{env.DOCSEARCH_APP_ID}}-dsn.algolia.net" crossorigin />
 {{/if}}


### PR DESCRIPTION
I noticed that we're still inserting the docsearch script on our beta site--and showing an error in the console as a result:

```
Uncaught TypeError: Cannot read properties of null (reading '__k')
    at gt (docsearch.js:2:32252)
    at docsearch.js:2:311077
    at latest/:1162:26
 ```

Matching the conditional handlebars we have in the [nav.hbs](https://github.com/mulesoft/docs-site-ui/blob/main/src/partials/nav.hbs#L3) to prevent that. I can confirm that that logic properly removes the docsearch div during current builds of the beta site.

Also, double-checked in a local preview that the script still gets inserted for the preview site. 