### PR TITLE
[W-19599483] Point icon to agent-visualizer component instead

### DIFF
--- a/preview-site-src/ui-model.yml
+++ b/preview-site-src/ui-model.yml
@@ -446,17 +446,17 @@ site:
             url: /runtime-manager/runtime-manager-cli.html
       versions:
       - *runtime_manager_latest
-    agent-fabric:
-      latest: &agent_fabric_latest
+    agent-visualizer:
+      latest: &agent_visualizer_latest
         version: ~
-        title: Agent Fabric
+        title: Agent Visualizer
         url: '#'
         navigation:
         - items:
-          - content: About Agent Fabric
+          - content: About Agent Visualizer
             url: '#'
       versions:
-      - *agent_fabric_latest
+      - *agent_visualizer_latest
 nav:
   subcomponents:
   - parent: connectors

--- a/src/js/vendor/icondefs.js
+++ b/src/js/vendor/icondefs.js
@@ -180,7 +180,7 @@
       ],
     },
     {
-      id: 'icon-nav-component-agent-fabric',
+      id: 'icon-nav-component-agent-visualizer',
       viewBox: '0 0 24 24',
       paths: [
         // lume-icons/product/agent-visualizer


### PR DESCRIPTION
Per the writing team, this icon should point to the new agent-visualizer repo. Agent Fabric's icon is still TBD.