### PR TITLE
[W-19478445] Add docsearch:version meta tag

### DIFF
--- a/src/partials/head/head-meta.hbs
+++ b/src/partials/head/head-meta.hbs
@@ -25,9 +25,11 @@
     {{#if (eq page.component.latest.version page.version)}}
         <meta name="is-latest-version" content="true">
         <meta name="version-with-latest" content="{{or page.displayVersion page.version}} {{#if (eq (site-profile) 'jp' )}}[最新]{{else}}[latest]{{/if}}">
+        <meta name="docsearch:version" content="latest">
     {{else}}
         <meta name="version-with-latest" content="{{or page.displayVersion page.version}}">
         <meta name="latest-version" content="{{page.component.latest.version}}">
+        <meta name="docsearch:version" content="{{page.version}}">
     {{/if}}
 
     {{#with (get-semver page.version)}}
@@ -46,6 +48,7 @@
 
 {{else}}
     <meta name="version-with-latest" content="{{or page.displayVersion page.version}} {{#if (eq (site-profile) 'jp' )}}[最新]{{else}}[latest]{{/if}}">
+    <meta name="docsearch:version" content="latest">
 {{/if}}
 
 {{#if (is-one-of (site-profile) "jp" "prod")}}


### PR DESCRIPTION
Docsearch allows you to pass a version through their expected `docsearch:version` meta tag.

For the purpose of displaying search results, I'm lumping together all docs that aren't an older version into `latest`. I.e. I only want old docs to display a specific numeric version. Note that I'm using page.version directly instead of displayVersion (as I don't want the version to include things like "2.9 (Mule 4.9)". 

My plan right now is to:

1. Get version embedded into our pages meta tags.
2. Crawl the latest version only one more time to add the version to our index.
3. Update our facet filter in JS to validate I can display content that matches a version, and if so, hardcode to latest.
4. Crawl all our pages, including content from previous versions. Search on the site will continue only showing latest.
5. Add JS to parse search queries and update the facet filter dynamically if a version matching some regex is included in the query. Experiment with filtering only to a specific version and filtering to latest and a specific version.
6. Optionally, add a badge or text string to results to indicate the version. 

I've done some local POC work to validate that I can dynamically update the facet filter based on queries and I believe this approach is viable.

**Testing**

Ran a full build of the playbook with this bundle to confirm that the meta tags are added properly. Note that I end