### PR TITLE
[W-19651097] Filter search to latest in preparation for crawling all versions

### DIFF
--- a/src/partials/footer/docsearch-scripts.hbs
+++ b/src/partials/footer/docsearch-scripts.hbs
@@ -3,6 +3,7 @@
 const searchContainer = '#docsearch'
 const searchText = MSCX.l10n.getMessage('search-toolbar-button')
 const langFilter = `lang:${MSCX.l10n.getLocale()}`
+const versionFilter = `version:latest`
 
 const docsearch = window.docsearch({
   container: searchContainer,
@@ -12,7 +13,7 @@ const docsearch = window.docsearch({
   disableUserPersonalization: true,
   maxResultsPerGroup: 10,
   searchParameters: {
-    facetFilters: [langFilter],
+    facetFilters: [langFilter, versionFilter],
   },
   translations: {
     button: { buttonText: searchText },


### PR DESCRIPTION
Follow up to this change: https://github.com/mulesoft/docs-site-ui/pull/890/files

The change took effect with the last crawl and now we can filter on version. Confirmed in the English and JP previews:


<img width="2317" height="805" alt="Screenshot 2025-09-22 at 10 39 56 AM" src="https://github.com/user-attachments/assets/d35b4e03-6e0e-46eb-9d0d-8aeddaa86731" />

<img width="2540" height="842" alt="Screenshot 2025-09-22 at 10 43 15 AM" src="https://github.com/user-attachments/assets/71e26dcb-6dd8-41fa-a9d8-76e5a8c27607" />
