### PR TITLE
[W-19478445] Remove obsolete function in docsearch

### DIFF
--- a/src/partials/footer/docsearch-scripts.hbs
+++ b/src/partials/footer/docsearch-scripts.hbs
@@ -18,16 +18,6 @@
 
   // Matches: 2.11, 1.13, 4.x
   // If version includes patch, remove: 2.5.3 -> returns 2.5
-  function parseVersionFromQuery (q) {
-    if (typeof q !== 'string' || !q) return null
-    const match = q.match(/(\d+)\.(\d+|x)(?:\.(\d+))?/i)
-    if (!match) return null
-    const major = match[1]
-    const minor = match[2]
-    if (typeof minor === 'string' && minor.toLowerCase() === 'x') return `${major}.x`
-    return `${major}.${minor}`
-  }
-
   function parseVersionsFromQuery (q) {
     if (typeof q !== 'string' || !q) return []
     const versions = new Set()


### PR DESCRIPTION
When I added support for users entering multiple versions in a query, it looks like I forgot to remove the original function that only handled one version.

Confirmed this wasn't used anywhere, and tested in a local preview to confirm everything still works.