### PR TITLE
@W-22052075 bugfix - release notes empty titles

### DIFF
--- a/src/helpers/release-notes.js
+++ b/src/helpers/release-notes.js
@@ -56,7 +56,7 @@ const getSelectedAttributes = (page) => {
     latestVersionAnchor: latestVersion?.anchor,
     latestVersionName: latestVersion?.versionName,
     revdateWithoutYear: removeYear(latestVersion?.releaseDate || page.attributes?.revdate),
-    title: latestVersion?.title,
+    title: latestVersion?.title || page.title,
     url: page.url,
   }
 }
@@ -162,7 +162,12 @@ const removeYear = (dateStr) => {
 const cleanTitle = (title, version) => {
   if (!title) return ''
 
-  const cleanedTitle = title.replace(/(Release Notes.*$)/i, '').trim()
+  let cleanedTitle
+  if (title.toLowerCase().startsWith('release notes for')) {
+    cleanedTitle = title.replace(/^([Rr]elease [Nn]otes [Ff]or\s*)/i, '').trim()
+  } else {
+    cleanedTitle = title.replace(/([Rr]elease [Nn]otes.*$)/i, '').trim()
+  }
 
   return version ? cleanedTitle.replace(versionRegex, '').trim() : cleanedTitle
 }

--- a/src/helpers/release-notes.js
+++ b/src/helpers/release-notes.js
@@ -162,12 +162,9 @@ const removeYear = (dateStr) => {
 const cleanTitle = (title, version) => {
   if (!title) return ''
 
-  let cleanedTitle
-  if (title.toLowerCase().startsWith('release notes for')) {
-    cleanedTitle = title.replace(/^([Rr]elease [Nn]otes [Ff]or\s*)/i, '').trim()
-  } else {
-    cleanedTitle = title.replace(/([Rr]elease [Nn]otes.*$)/i, '').trim()
-  }
+  const cleanedTitle = title.toLowerCase().startsWith('release notes for')
+    ? title.replace(/^([Rr]elease [Nn]otes [Ff]or\s*)/i, '').trim()
+    : title.replace(/([Rr]elease [Nn]otes.*$)/i, '').trim()
 
   return version ? cleanedTitle.replace(versionRegex, '').trim() : cleanedTitle
 }


### PR DESCRIPTION
[W-22052075](https://gus.lightning.force.com/a07EE00002YDeZfYAL)

Update release notes helper to handle missing titles and improve title cleaning logic. 

The page with the missing release notes title is "Release Notes for APIkit for OData v4 1.6.0" whereas most pages have the title in the format of "XYZ Release Notes". Because of the "XYZ Release Notes" format, the release notes helper's original logic is to remove "Release Notes" and everything after in the title, assuming that "Release Notes" is at the end. In this case, the title has "Release Notes" at the beginning so the entire title was removed.

This PR adds an additional check on the page title. If "Release Notes For" is in the beginning, then remove it, otherwise assume "Release notes" is at the end and remove it and everything after it. Additionally I added one more gate in case the title is still blank, then just default to the page title as-is. It's going to include "Release Notes" in the link but it's better than a blank item.
