### PR TITLE
@W-22198794 add slight delay to link tracking

### DIFF
--- a/src/js/23-page-format-dropdown.js
+++ b/src/js/23-page-format-dropdown.js
@@ -1,6 +1,15 @@
 ;(() => {
   'use strict'
 
+  /** @param {string} pageAction */
+  const pushPageAction = (pageAction) => {
+    window.dataLayer = window.dataLayer || []
+    window.dataLayer.push({
+      event: 'page_actions',
+      page_action: pageAction,
+    })
+  }
+
   const dropdowns = document.querySelectorAll('.page-options-dropdown')
   if (!dropdowns.length) return
 
@@ -99,6 +108,12 @@
         })
     }
 
+    if (primaryBtn) {
+      primaryBtn.addEventListener('click', () => {
+        pushPageAction('copy-md-primary')
+      })
+    }
+
     // Tooltip for copy feedback
     let copyTooltip
     if (primaryBtn && typeof tippy === 'function') {
@@ -126,6 +141,7 @@
     const menuCopyBtn = optionsPanel.querySelector('[data-action="copy-md"]')
     if (menuCopyBtn) {
       menuCopyBtn.addEventListener('click', () => {
+        pushPageAction('copy-md-menu')
         copyMd()
         closeMenu(true)
       })
@@ -133,6 +149,7 @@
 
     toggle.addEventListener('click', () => {
       const expanded = toggle.getAttribute('aria-expanded') === 'true'
+      pushPageAction(expanded ? 'menu-close' : 'menu-open')
       if (expanded) {
         closeMenu(false)
       } else {
@@ -182,6 +199,8 @@
     // Close after clicking a link item
     optionsPanel.querySelectorAll('a[role="menuitem"]').forEach((link) => {
       link.addEventListener('click', () => {
+        const action = link.getAttribute('data-action')
+        if (action) pushPageAction(action)
         closeMenu(false)
       })
     })

--- a/src/js/23-page-format-dropdown.js
+++ b/src/js/23-page-format-dropdown.js
@@ -1,15 +1,6 @@
 ;(() => {
   'use strict'
 
-  /** @param {string} pageAction */
-  const pushPageAction = (pageAction) => {
-    window.dataLayer = window.dataLayer || []
-    window.dataLayer.push({
-      event: 'page_actions',
-      page_action: pageAction,
-    })
-  }
-
   const dropdowns = document.querySelectorAll('.page-options-dropdown')
   if (!dropdowns.length) return
 
@@ -110,7 +101,13 @@
 
     if (primaryBtn) {
       primaryBtn.addEventListener('click', () => {
-        pushPageAction('copy-md-primary')
+        const h1 = document.querySelector('h1')
+        window.dataLayer = window.dataLayer || []
+        window.dataLayer.push({
+          event: 'custEv_ctaLink',
+          clickText: primaryBtn.textContent.trim(),
+          itemTitle: h1 ? h1.textContent.trim() : document.title,
+        })
       })
     }
 
@@ -141,7 +138,13 @@
     const menuCopyBtn = optionsPanel.querySelector('[data-action="copy-md"]')
     if (menuCopyBtn) {
       menuCopyBtn.addEventListener('click', () => {
-        pushPageAction('copy-md-menu')
+        const h1 = document.querySelector('h1')
+        window.dataLayer = window.dataLayer || []
+        window.dataLayer.push({
+          event: 'custEv_ctaLink',
+          clickText: menuCopyBtn.textContent.trim(),
+          itemTitle: h1 ? h1.textContent.trim() : document.title,
+        })
         copyMd()
         closeMenu(true)
       })
@@ -149,7 +152,6 @@
 
     toggle.addEventListener('click', () => {
       const expanded = toggle.getAttribute('aria-expanded') === 'true'
-      pushPageAction(expanded ? 'menu-close' : 'menu-open')
       if (expanded) {
         closeMenu(false)
       } else {
@@ -199,8 +201,13 @@
     // Close after clicking a link item
     optionsPanel.querySelectorAll('a[role="menuitem"]').forEach((link) => {
       link.addEventListener('click', () => {
-        const action = link.getAttribute('data-action')
-        if (action) pushPageAction(action)
+        const h1 = document.querySelector('h1')
+        window.dataLayer = window.dataLayer || []
+        window.dataLayer.push({
+          event: 'custEv_ctaLink',
+          clickText: link.textContent.trim(),
+          itemTitle: h1 ? h1.textContent.trim() : document.title,
+        })
         closeMenu(false)
       })
     })

--- a/src/js/23-page-format-dropdown.js
+++ b/src/js/23-page-format-dropdown.js
@@ -197,9 +197,22 @@
 
     // Close after clicking a link item
     optionsPanel.querySelectorAll('a[role="menuitem"]').forEach((link) => {
-      link.addEventListener('click', () => {
-        pushCtaLink(link.textContent.trim(), link.href)
-        closeMenu(false)
+      link.addEventListener('click', (e) => {
+        const willOpenInNewTab = link.target === '_blank' || link.target === '_new'
+
+        if (willOpenInNewTab) {
+          e.preventDefault()
+          pushCtaLink(link.textContent.trim(), link.href)
+
+          // Wait for GA to send the hit, then open link
+          setTimeout(() => {
+            window.open(link.href, '_blank')
+            closeMenu(false)
+          }, 300)
+        } else {
+          pushCtaLink(link.textContent.trim(), link.href)
+          closeMenu(false)
+        }
       })
     })
   })

--- a/src/js/23-page-format-dropdown.js
+++ b/src/js/23-page-format-dropdown.js
@@ -1,6 +1,16 @@
 ;(() => {
   'use strict'
 
+  const pushCtaLink = (clickText) => {
+    const h1 = document.querySelector('h1')
+    window.dataLayer = window.dataLayer || []
+    window.dataLayer.push({
+      event: 'custEv_ctaLink',
+      clickText,
+      itemTitle: h1 ? h1.textContent.trim() : document.title,
+    })
+  }
+
   const dropdowns = document.querySelectorAll('.page-options-dropdown')
   if (!dropdowns.length) return
 
@@ -99,18 +109,6 @@
         })
     }
 
-    if (primaryBtn) {
-      primaryBtn.addEventListener('click', () => {
-        const h1 = document.querySelector('h1')
-        window.dataLayer = window.dataLayer || []
-        window.dataLayer.push({
-          event: 'custEv_ctaLink',
-          clickText: primaryBtn.textContent.trim(),
-          itemTitle: h1 ? h1.textContent.trim() : document.title,
-        })
-      })
-    }
-
     // Tooltip for copy feedback
     let copyTooltip
     if (primaryBtn && typeof tippy === 'function') {
@@ -127,9 +125,11 @@
         theme: 'copy-link-popover',
         zIndex: 'var(--z-nav-mobile)',
       })
+    }
 
-      // Primary button directly copies
+    if (primaryBtn) {
       primaryBtn.addEventListener('click', () => {
+        pushCtaLink(primaryBtn.textContent.trim())
         copyMd()
       })
     }
@@ -138,13 +138,7 @@
     const menuCopyBtn = optionsPanel.querySelector('[data-action="copy-md"]')
     if (menuCopyBtn) {
       menuCopyBtn.addEventListener('click', () => {
-        const h1 = document.querySelector('h1')
-        window.dataLayer = window.dataLayer || []
-        window.dataLayer.push({
-          event: 'custEv_ctaLink',
-          clickText: menuCopyBtn.textContent.trim(),
-          itemTitle: h1 ? h1.textContent.trim() : document.title,
-        })
+        pushCtaLink(menuCopyBtn.textContent.trim())
         copyMd()
         closeMenu(true)
       })
@@ -201,13 +195,7 @@
     // Close after clicking a link item
     optionsPanel.querySelectorAll('a[role="menuitem"]').forEach((link) => {
       link.addEventListener('click', () => {
-        const h1 = document.querySelector('h1')
-        window.dataLayer = window.dataLayer || []
-        window.dataLayer.push({
-          event: 'custEv_ctaLink',
-          clickText: link.textContent.trim(),
-          itemTitle: h1 ? h1.textContent.trim() : document.title,
-        })
+        pushCtaLink(link.textContent.trim())
         closeMenu(false)
       })
     })

--- a/src/js/23-page-format-dropdown.js
+++ b/src/js/23-page-format-dropdown.js
@@ -10,7 +10,7 @@
       itemTitle: h1 ? h1.textContent.trim() : document.title,
       clickUrl,
       elementType: 'link',
-      contentType: 'Page Options Dropdown',
+      contentType: 'AI',
     })
   }
 

--- a/src/js/23-page-format-dropdown.js
+++ b/src/js/23-page-format-dropdown.js
@@ -1,7 +1,7 @@
 ;(() => {
   'use strict'
 
-  const pushCtaLink = (clickText, clickUrl) => {
+  const pushCtaLink = (clickText, clickUrl, callback) => {
     const h1 = document.querySelector('h1')
     window.dataLayer = window.dataLayer || []
     window.dataLayer.push({
@@ -11,6 +11,8 @@
       clickUrl,
       elementType: 'link',
       contentType: 'AI',
+      eventCallback: callback || (() => {}),
+      eventTimeout: 2000,
     })
   }
 
@@ -202,13 +204,10 @@
 
         if (willOpenInNewTab) {
           e.preventDefault()
-          pushCtaLink(link.textContent.trim(), link.href)
-
-          // Wait for GA to send the hit, then open link
-          setTimeout(() => {
+          pushCtaLink(link.textContent.trim(), link.href, () => {
             window.open(link.href, '_blank')
             closeMenu(false)
-          }, 300)
+          })
         } else {
           pushCtaLink(link.textContent.trim(), link.href)
           closeMenu(false)

--- a/src/js/23-page-format-dropdown.js
+++ b/src/js/23-page-format-dropdown.js
@@ -1,13 +1,16 @@
 ;(() => {
   'use strict'
 
-  const pushCtaLink = (clickText) => {
+  const pushCtaLink = (clickText, clickUrl) => {
     const h1 = document.querySelector('h1')
     window.dataLayer = window.dataLayer || []
     window.dataLayer.push({
-      event: 'custEv_ctaLink',
+      event: 'content_click',
       clickText,
       itemTitle: h1 ? h1.textContent.trim() : document.title,
+      clickUrl,
+      elementType: 'link',
+      contentType: 'Page Options Dropdown',
     })
   }
 
@@ -129,7 +132,7 @@
 
     if (primaryBtn) {
       primaryBtn.addEventListener('click', () => {
-        pushCtaLink(primaryBtn.textContent.trim())
+        pushCtaLink(primaryBtn.textContent.trim(), mdUrl)
         copyMd()
       })
     }
@@ -138,7 +141,7 @@
     const menuCopyBtn = optionsPanel.querySelector('[data-action="copy-md"]')
     if (menuCopyBtn) {
       menuCopyBtn.addEventListener('click', () => {
-        pushCtaLink(menuCopyBtn.textContent.trim())
+        pushCtaLink(menuCopyBtn.textContent.trim(), mdUrl)
         copyMd()
         closeMenu(true)
       })
@@ -195,7 +198,7 @@
     // Close after clicking a link item
     optionsPanel.querySelectorAll('a[role="menuitem"]').forEach((link) => {
       link.addEventListener('click', () => {
-        pushCtaLink(link.textContent.trim())
+        pushCtaLink(link.textContent.trim(), link.href)
         closeMenu(false)
       })
     })

--- a/src/partials/page-actions-dropdown.hbs
+++ b/src/partials/page-actions-dropdown.hbs
@@ -12,7 +12,7 @@
     <div class="page-options-menu-group" role="group">
       <a role="menuitem" tabindex="-1" data-action="view-md" rel="noopener" target="_blank">View as Markdown <img class="external-link-image" src="{{@root.uiRootPath}}/img/icons/external-link.svg" alt="" aria-hidden="true"><span class="sr-only">(opens in new tab)</span></a>
       {{#if (or preview (and (ne (site-profile) "archive") (or (and page.fileUri (not env.CI)) (and page.editUrl (not page.origin.private))))) }}
-      <a role="menuitem" tabindex="-1" rel="noopener" target="_blank"
+      <a role="menuitem" tabindex="-1" data-action="view-github" rel="noopener" target="_blank"
         {{#if (and page.fileUri (not env.CI))}}
         href="{{page.fileUri}}"
         {{else}}


### PR DESCRIPTION
## Summary                                       

Fix analytics data loss for links opening in new tabs.
                                                   
## Changes                                       

- Use `eventCallback` to ensure GA hits complete before new tabs open (~50-100ms delay, 2s fallback)
                                                 
## Why eventCallback?

Without it, browsers cancel pending GA network requests when opening new tabs, causing data loss in GA360 even though GTM Tag Assistant shows tags fired.

## Test plan
- [ ] Copy button sends `content_click` event
- [ ] ChatGPT/Claude/Perplexity links tracked in GA360 (not just Tag Assistant)                   
- [ ] New tabs open without noticeable delay
- [ ] Verify events appear in GA360 Explore with custom parameters  