### PR TITLE
@W-22472106 Deduplicate meta description for topics with page description

### DIFF
--- a/gulp.d/tasks/build-preview-pages.js
+++ b/gulp.d/tasks/build-preview-pages.js
@@ -63,6 +63,7 @@ module.exports =
                   const attributes = doc.getAttributes()
                   pageModel.layout = doc.getAttribute('page-layout', 'default')
                   pageModel.title = doc.getDocumentTitle()
+                  pageModel.description = doc.getAttribute('description', doc.getAttribute('page-description'))
                   pageModel.url = '/' + file.relative.slice(0, -5) + '.html'
                   if (file.stem === 'home') {
                     pageModel.home = true

--- a/preview-site-src/index.adoc
+++ b/preview-site-src/index.adoc
@@ -1,5 +1,6 @@
 = [.brand]#MuleSoft# Documentation
 :page-layout: home
+:description: Custom page description should override generic meta description
 :page-fragmentize:
 :!sectids:
 ifndef::env-site[:imagesdir: ../images]

--- a/src/partials/head/head-meta.hbs
+++ b/src/partials/head/head-meta.hbs
@@ -6,6 +6,8 @@
 
 {{#if page.description}}
     <meta name="description" content="{{page.description}}">
+{{else if (is-one-of (site-profile) "jp" "prod" "preview")}}
+    <meta name="description" content="MuleSoft Documentation Site">
 {{/if}}
 
 {{#if page.keywords}}
@@ -49,10 +51,6 @@
 {{else}}
     <meta name="version-with-latest" content="{{or page.displayVersion page.version}} {{#if (eq (site-profile) 'jp' )}}[最新]{{else}}[latest]{{/if}}">
     <meta name="docsearch:version" content="latest">
-{{/if}}
-
-{{#if (is-one-of (site-profile) "jp" "prod")}}
-    <meta name="description" content="MuleSoft Documentation Site">
 {{/if}}
 
 <meta name="google-site-verification" content="NDIrUbizqamSncO6tSzBUHFR8VIKcjAocR4UrnKau2s" />


### PR DESCRIPTION
As part of the llms.txt work, I'm going to allow writers to set custom descriptions for their topic links in llms.txt. Rather than make a new arbitrary page attribute, I'm pointing to meta description. This makes sense because:

* Antora supports this out of the box with `:description:`
* Writers have wanted to add short descriptions to topics for some time now anyway, and so they'll be able to get both with one change whenever they get to it.

There's a small bug right now though that causes pages to get two meta descriptions, e.g.

```
<meta name="description" content="Description from topic">
<meta name="description" content="MuleSoft Documentation Site">
```

This PR deduplicates those tags. It also patches the preview site to include description in the page model for local testing.

## Testing

Verified in local preview