### PR TITLE
@w-22569098 Add handling for view-md and view-github actions in dropdown links

### DIFF
--- a/src/js/23-page-format-dropdown.js
+++ b/src/js/23-page-format-dropdown.js
@@ -201,6 +201,15 @@
     optionsPanel.querySelectorAll('a[role="menuitem"]').forEach((link) => {
       link.addEventListener('click', (e) => {
         const willOpenInNewTab = link.target === '_blank' || link.target === '_new'
+        const action = link.getAttribute('data-action')
+
+        // Skip preventDefault for view-md and view-github since they already have href set
+        // and we don't want to open them twice
+        if (action === 'view-md' || action === 'view-github') {
+          pushCtaLink(link.textContent.trim(), link.href)
+          closeMenu(false)
+          return
+        }
 
         if (willOpenInNewTab) {
           e.preventDefault()


### PR DESCRIPTION
## Fix: Prevent "View on GitHub" link from opening multiple tabs               

### Problem                              
Clicking "View on GitHub" opened multiple browser tabs.                           
                                         
### Root Cause                           
Links with pre-set `href` attributes ("View as Markdown" and "View on GitHub") were being opened twice:
  1. By the browser's native `target="_blank"` handling               
  2. By the JavaScript `window.open()` call in the click handler                    
                                         
  ### Solution                             
  Skip `preventDefault()` and `window.open()` for `view-md` and `view-github` actions, letting the browser handle navigation naturally while still tracking analytics.