### PR TITLE
@W-22569098 clean up clickText

### DIFF
--- a/src/js/23-page-format-dropdown.js
+++ b/src/js/23-page-format-dropdown.js
@@ -3,10 +3,13 @@
 
   const pushCtaLink = (clickText, clickUrl, callback) => {
     const h1 = document.querySelector('h1')
+    const cleanClickText = clickText.endsWith(' (opens in new tab)')
+      ? clickText.slice(0, -' (opens in new tab)'.length)
+      : clickText
     window.dataLayer = window.dataLayer || []
     window.dataLayer.push({
       event: 'custEv_ctaLink',
-      clickText,
+      clickText: cleanClickText,
       itemTitle: h1 ? h1.textContent.trim() : document.title,
       clickUrl,
       elementType: 'link',

--- a/src/js/23-page-format-dropdown.js
+++ b/src/js/23-page-format-dropdown.js
@@ -201,6 +201,15 @@
     optionsPanel.querySelectorAll('a[role="menuitem"]').forEach((link) => {
       link.addEventListener('click', (e) => {
         const willOpenInNewTab = link.target === '_blank' || link.target === '_new'
+        const action = link.getAttribute('data-action')
+
+        // Skip preventDefault for view-md and view-github since they already have href set
+        // and we don't want to open them twice
+        if (action === 'view-md' || action === 'view-github') {
+          pushCtaLink(link.textContent.trim(), link.href)
+          closeMenu(false)
+          return
+        }
 
         if (willOpenInNewTab) {
           e.preventDefault()


### PR DESCRIPTION
if clickText ends with " (opens in new tab)", remove it. Example: "View on GitHub (opens in new tab)" -> "View on GitHub". This cleans up the label in web analytics.