### PR TITLE
@W-22198794 remove Japanese "Open in New Tab"

### DIFF
--- a/src/js/23-page-format-dropdown.js
+++ b/src/js/23-page-format-dropdown.js
@@ -3,9 +3,7 @@
 
   const pushCtaLink = (clickText, clickUrl, callback) => {
     const h1 = document.querySelector('h1')
-    const cleanClickText = clickText.endsWith(' (opens in new tab)')
-      ? clickText.slice(0, -' (opens in new tab)'.length)
-      : clickText
+    const cleanClickText = clickText.replace(/\s*[(（][^)）]*[)）]\s*$/, '')
     window.dataLayer = window.dataLayer || []
     window.dataLayer.push({
       event: 'custEv_ctaLink',


### PR DESCRIPTION
update logic to remove any suffixes in clickText that is in parentheses. For example: `(Open in New Tab)` or `（新しいタブで開きます）`